### PR TITLE
ci: add Go module and Docker buildx caching to workflows

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -3,6 +3,9 @@ on: [pull_request]
 jobs:
   build-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     env:
       REPOSITORY: ghcr.io/${{ github.repository }}
     steps:
@@ -16,4 +19,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ghcr.io/${{ github.repository }}:latest-amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,14 @@ jobs:
     env:
       GO111MODULE: on
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: '${{ matrix.go-version }}'
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+        cache: true
 
     - name: Build
       env:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,6 +12,8 @@ jobs:
     name: Docker build
     runs-on: ${{ matrix.runner }}
     permissions:
+      contents: read
+      actions: write
       packages: write
     strategy:
       matrix:
@@ -51,6 +53,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           tags: ghcr.io/${{ github.repository }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -73,6 +77,7 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
     needs:
       - build-images

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,11 @@ jobs:
       run: go env -w GOTOOLCHAIN=go${{ matrix.go-version }}+auto
 
 
+    - name: Load kernel modules
+      run: sudo modprobe nft_ct
+
     - name: Test
-      run: sudo modprobe nft_ct && sudo go test -v -coverprofile=profile.cov ./...
+      run: go test -v -coverprofile=profile.cov ./...
 
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,9 @@ jobs:
       run: sudo modprobe nft_ct
 
     - name: Test
-      run: go test -v -coverprofile=profile.cov ./...
+      run: |
+        sudo go test -v -coverprofile=profile.cov ./...
+        sudo chown $(id -u):$(id -g) profile.cov
 
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,14 @@ jobs:
         os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-
-    - name: Checkout code
-      uses: actions/checkout@v4
+        cache: true
 
     - name: Run Revive Action by pulling pre-built image
       uses: docker://morphy/revive-action:v2


### PR DESCRIPTION
## Summary
- Enable Go module caching (`cache: true`) in `setup-go` for test and build workflows
- Enable Docker buildx GHA layer caching (`cache-from/to: type=gha`) in docker-image and build-images workflows
- Significantly reduces CI execution time by avoiding redundant dependency downloads and layer rebuilds

## Changes
- `.github/workflows/test.yml` — add `cache: true` to setup-go
- `.github/workflows/build.yml` — add `cache: true` to setup-go
- `.github/workflows/docker-image.yml` — add buildx GHA cache to build-push-action
- `.github/workflows/build-images.yml` — add buildx GHA cache to build-push-action