### PR TITLE
chore: harden Dockerfile with structured layers and best practices

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.gitignore
+.golangci.yaml
+*.md
+LICENSE
+LICENSES/
+e2e/
+hack/
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,31 @@
 # This Dockerfile is used to build the image available on DockerHub
 FROM golang:1.25 AS build
 
-# Add everything
-ADD . /usr/src/multi-networkpolicy-nftables
+WORKDIR /usr/src/multi-networkpolicy-nftables
 
-RUN cd /usr/src/multi-networkpolicy-nftables && \
-    CGO_ENABLED=0 go build ./cmd/multi-networkpolicy-nftables/
+# Copy dependency files first for better layer caching
+COPY go.mod go.sum ./
+COPY vendor/ vendor/
+
+# Copy source code
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /usr/bin/multi-networkpolicy-nftables ./cmd/multi-networkpolicy-nftables/
 
 FROM docker.io/debian:stable-slim
-LABEL org.opencontainers.image.source=https://github.com/telekom/multi-networkpolicy-nftables
-RUN apt update \
-    && apt install -y --no-install-recommends \
+
+LABEL org.opencontainers.image.source="https://github.com/telekom/multi-networkpolicy-nftables"
+LABEL org.opencontainers.image.description="Multi-NetworkPolicy enforcement using nftables"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
     nftables \
-    && apt clean \
-    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && touch -d "2 hours ago" /var/lib/apt/lists
-COPY --from=build /usr/src/multi-networkpolicy-nftables/multi-networkpolicy-nftables /usr/bin
-WORKDIR /usr/bin
+    && rm -rf /usr/share/doc /usr/share/man
+
+COPY --from=build /usr/bin/multi-networkpolicy-nftables /usr/bin/multi-networkpolicy-nftables
 
 ENTRYPOINT ["multi-networkpolicy-nftables"]


### PR DESCRIPTION
## Summary
- Replace `ADD .` with structured `COPY` layers for optimal Docker build caching
- Add `.dockerignore` to exclude unnecessary files from build context
- Add `-ldflags="-s -w"` to strip debug symbols (smaller binary)
- Add OCI image labels (description, license)
- Use `apt-get` instead of `apt` (best practice for non-interactive scripts)
- Remove unnecessary `WORKDIR /usr/bin` and apt timestamp hack

## Why
- Structured COPY layers mean source code changes don't invalidate the dependency layer
- `.dockerignore` reduces build context size (excludes .git, e2e tests, docs)
- Stripped binary is smaller
- OCI labels improve image discoverability in container registries

## Note
The container intentionally runs as root — the daemon requires CAP_NET_ADMIN to manage nftables rules in pod network namespaces via a privileged DaemonSet.