### PR TITLE
test(e2e): add robust teardown and remove cleanup test blocks

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      actions: write
       packages: write
     strategy:
       matrix:

--- a/e2e/run_all_tests.sh
+++ b/e2e/run_all_tests.sh
@@ -6,7 +6,32 @@ pushd ${E2E}
 
 suite_failed=0
 
+cleanup_on_exit() {
+    status="$1"
+    signal="$2"
+
+    if [ "$status" -ne 0 ] || [ "$suite_failed" -ne 0 ]; then
+        echo "Test suite failed — collecting kind logs..."
+        ./bin/kind export logs ./artifacts/suite-failure/kind-logs 2>/dev/null || true
+    fi
+
+    case "$signal" in
+        INT)
+            trap - INT
+            exit 130
+            ;;
+        TERM)
+            trap - TERM
+            exit 143
+            ;;
+    esac
+}
+trap 'cleanup_on_exit $? EXIT' EXIT
+trap 'cleanup_on_exit $? INT' INT
+trap 'cleanup_on_exit $? TERM' TERM
+
 for f in ./tests/*.bats; do
+    echo "=== Running: $(basename $f) ==="
     bats $f
     retval=$?
     if [ $retval -ne 0 ]; then

--- a/e2e/tests/bond-cni.bats
+++ b/e2e/tests/bond-cni.bats
@@ -1,24 +1,27 @@
 #!/usr/bin/env bats
 
-setup() {
+setup_file() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	pod_a_net1=$(get_net1_ip "bond-testing" "pod-a")
-	pod_b_net1=$(get_net1_ip "bond-testing" "pod-b")
-	pod_c_net1=$(get_net1_ip "bond-testing" "pod-c")
-}
-
-@test "setup resources" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f bond-cni.yml
-
-	# verify all pods are available
-	run kubectl -n bond-testing wait --for=condition=ready -l app=bond-testing pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
+	export MANIFEST_FILE="bond-cni.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n bond-testing wait --for=condition=ready -l app=bond-testing pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "bond-testing" "pod-a" "test-multinetwork-policy-bond"
 	sleep 2
 }
+
+setup() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	pod_a_net1=$(wait_for_net1_ip "bond-testing" "pod-a")
+	pod_b_net1=$(wait_for_net1_ip "bond-testing" "pod-b")
+	pod_c_net1=$(wait_for_net1_ip "bond-testing" "pod-c")
+}
+
+teardown_file() {
+	teardown_file_common
+}
+
 
 @test "bond-testing check pod-b -> pod-a" {
 	run kubectl -n bond-testing exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
@@ -26,23 +29,16 @@ setup() {
 }
 
 @test "bond-testing check pod-c -> pod-a" {
-	run kubectl -n bond-testing exec pod-c -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n bond-testing exec pod-c -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "bond-testing check pod-a -> pod-b" {
-	run kubectl -n bond-testing exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n bond-testing exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "bond-testing check pod-a -> pod-c" {
 	run kubectl -n bond-testing exec pod-a -- sh -c "echo x | nc -w 1 ${pod_c_net1} 5555"
-	[ "$status" -eq  "0" ]
-}
-
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f bond-cni.yml
-	run kubectl -n bond-testing wait --for=delete -l app=bond-testing pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/common.bash
+++ b/e2e/tests/common.bash
@@ -38,6 +38,32 @@ get_net2_ip6() {
 	fi
 }
 
+# teardown_file_common — base cleanup logic shared by all .bats files.
+# Deletes the manifest (MANIFEST_FILE) and optional extra namespaces (CLEANUP_NAMESPACES).
+# Each .bats file's teardown_file() MUST call this function:
+#
+#   teardown_file() {
+#       teardown_file_common
+#       # optional: additional cleanup
+#   }
+#
+teardown_file_common() {
+	if [ -n "${MANIFEST_FILE:-}" ]; then
+		cd "$BATS_TEST_DIRNAME"
+		echo "# Cleaning up: kubectl delete -f ${MANIFEST_FILE}" >&3
+		if ! kubectl delete --ignore-not-found --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"; then
+			echo "# WARNING: cleanup of ${MANIFEST_FILE} failed" >&3
+		fi
+	fi
+	if [ -n "${CLEANUP_NAMESPACES:-}" ]; then
+		for ns in ${CLEANUP_NAMESPACES}; do
+			if ! kubectl delete namespace --ignore-not-found --wait --timeout=${kubewait_timeout} "${ns}"; then
+				echo "# WARNING: cleanup of namespace ${ns} failed" >&3
+			fi
+		done
+	fi
+}
+
 # wait_for_net1_ip waits for a non-empty net1 IPv4 address on the given pod.
 # Usage: ip=$(wait_for_net1_ip <namespace> <pod-name>)
 # Returns non-zero if the IP cannot be resolved within the timeout.
@@ -89,12 +115,57 @@ retry_until_success() {
 	return 1
 }
 
+# retry_until_deny retries a command until it exits with non-zero status (i.e., traffic is blocked).
+# This is needed because nft rules appearing in 'nft list ruleset' does not guarantee they are
+# immediately effective for packet filtering (kernel asynchrony on bond/vlan interfaces).
+# Usage: retry_until_deny <max_retries> <command...>
+retry_until_deny() {
+	local max_retries=$1
+	shift
+	local attempt=1
+	while [ $attempt -le $max_retries ]; do
+		if ! "$@" 2>/dev/null; then
+			return 0
+		fi
+		echo "# Deny attempt $attempt/$max_retries - traffic still allowed, retrying..." >&3
+		sleep 2
+		attempt=$((attempt + 1))
+	done
+	echo "# Deny failed after $max_retries attempts: traffic still not blocked by: $*" >&3
+	return 1
+}
+
+# retry_until_allow retries a command until it exits with zero status (i.e., traffic is allowed).
+# This is needed because nft rules appearing in 'nft list ruleset' does not guarantee they are
+# immediately effective for packet filtering (kernel asynchrony on bond/vlan interfaces).
+# Usage: retry_until_allow <max_retries> <command...>
+retry_until_allow() {
+	local max_retries=$1
+	shift
+	local attempt=1
+	while [ $attempt -le $max_retries ]; do
+		if "$@" 2>/dev/null; then
+			return 0
+		fi
+		echo "# Allow attempt $attempt/$max_retries - traffic still blocked, retrying..." >&3
+		sleep 2
+		attempt=$((attempt + 1))
+	done
+	echo "# Allow failed after $max_retries attempts: traffic still not allowed by: $*" >&3
+	return 1
+}
+
 # wait_for_nft_rules waits until nftables rules containing the given pattern appear in a pod.
 # Usage: wait_for_nft_rules <namespace> <pod> <grep_pattern> [max_retries]
 wait_for_nft_rules() {
 	local ns=$1
 	local pod=$2
 	local pattern=$3
-	local max_retries=${4:-15}
+	local max_retries=${4:-30}
 	retry_until_success "$max_retries" kubectl -n "$ns" exec "$pod" -- sh -c "nft list ruleset | grep -q '$pattern'"
 }
+
+# setup_file — called by BATS before any test in a file runs.
+# Each .bats file MUST override setup_file() to set MANIFEST_FILE,
+# AND MUST define teardown_file() that calls teardown_file_common.
+# CLEANUP_NAMESPACES is optional for multi-namespace tests (space-separated list of namespaces to delete).

--- a/e2e/tests/ingress-ns-selector-no-pods.bats
+++ b/e2e/tests/ingress-ns-selector-no-pods.bats
@@ -5,36 +5,39 @@
 # These test cases verify that an ingress rule on the server that matches no pods 
 # does not allow any pods to reach the server.
 
-setup() {
+setup_file() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	server_net1=$(get_net1_ip "test-ingress-ns-selector-no-pods" "pod-server")
-	client_a_net1=$(get_net1_ip "test-ingress-ns-selector-no-pods" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-ingress-ns-selector-no-pods-blue" "pod-client-b")
-}
-
-@test "setup ingress-ns-selector-no-pods test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f ingress-ns-selector-no-pods.yml
-
-	# verify all pods are available
-	run kubectl -n test-ingress-ns-selector-no-pods wait --for=condition=ready -l app=test-ingress-ns-selector-no-pods pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
+	export MANIFEST_FILE="ingress-ns-selector-no-pods.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-ingress-ns-selector-no-pods wait --for=condition=ready -l app=test-ingress-ns-selector-no-pods pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-ingress-ns-selector-no-pods" "pod-server" "policy-test-ingress-ns-selector-no-pods"
 	sleep 2
 }
 
+setup() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	server_net1=$(wait_for_net1_ip "test-ingress-ns-selector-no-pods" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-ingress-ns-selector-no-pods" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-ingress-ns-selector-no-pods-blue" "pod-client-b")
+}
+
+teardown_file() {
+	teardown_file_common
+}
+
+
 @test "test-ingress-ns-selector-no-pods check client-a -> server" {
 	# nc should NOT succeed from client-a to server by policy
-	run kubectl -n test-ingress-ns-selector-no-pods exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-ingress-ns-selector-no-pods exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-ingress-ns-selector-no-pods check client-b -> server" {
 	# nc should NOT succeed from client-b to server by policy
-	run kubectl -n test-ingress-ns-selector-no-pods-blue exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-ingress-ns-selector-no-pods-blue exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-ingress-ns-selector-no-pods check server -> client-a" {
@@ -46,12 +49,5 @@ setup() {
 @test "test-ingress-ns-selector-no-pods check server -> client-b" {
 	# nc should succeed from server to client-b by no policy definition for direction (egress for pod-server)
 	run kubectl -n test-ingress-ns-selector-no-pods exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
-	[ "$status" -eq  "0" ]
-}
-
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f ingress-ns-selector-no-pods.yml
-	run kubectl -n test-ingress-ns-selector-no-pods wait --for=delete -l app=test-ingress-ns-selector-no-pods pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/ipblock-list.bats
+++ b/e2e/tests/ipblock-list.bats
@@ -4,23 +4,29 @@
 # These test cases, stacked, will create stacked policy rules in one multi-networkpolicy and test the
 # traffic policying by ncat (nc) command.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="ipblock-list.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-ipblock-list wait --for=condition=ready -l app=test-ipblock-list pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-ipblock-list" "pod-server" "testnetwork-policy-ipblock-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
 
-	server_net1=$(get_net1_ip "test-ipblock-list" "pod-server")
-	client_a_net1=$(get_net1_ip "test-ipblock-list" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-ipblock-list" "pod-client-b")
-	client_c_net1=$(get_net1_ip "test-ipblock-list" "pod-client-c")
+	server_net1=$(wait_for_net1_ip "test-ipblock-list" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-ipblock-list" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-ipblock-list" "pod-client-b")
+	client_c_net1=$(wait_for_net1_ip "test-ipblock-list" "pod-client-c")
 }
 
-@test "setup ipblock-list test environments" {
-	kubectl apply --wait --timeout=${kubewait_timeout} -f ipblock-list.yml
-	run kubectl -n test-ipblock-list wait --for=condition=ready -l app=test-ipblock-list pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-ipblock-list" "pod-server" "testnetwork-policy-ipblock-1"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "test-ipblock-list check client-a" {
 	run kubectl -n test-ipblock-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
@@ -33,12 +39,6 @@ setup() {
 }
 
 @test "test-ipblock-list check client-c" {
-	run kubectl -n test-ipblock-list exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
-}
-
-@test "cleanup environments" {
-	kubectl delete -f ipblock-list.yml
-	run kubectl -n test-ipblock-list wait --for=delete -l app=test-ipblock-list pod --timeout=${kubewait_timeout}
+	run retry_until_deny 10 kubectl -n test-ipblock-list exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/ipblock-stacked.bats
+++ b/e2e/tests/ipblock-stacked.bats
@@ -4,24 +4,30 @@
 # These test cases, stacked, will create stacked policy rules in one multi-networkpolicy and test the
 # traffic policying by ncat (nc) command.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="ipblock-stacked.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-ipblock-stacked wait --for=condition=ready -l app=test-ipblock-stacked pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-ipblock-stacked" "pod-server" "testnetwork-policy-ipblock-stacked-1"
+	sleep 2
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
 
-	server_net1=$(get_net1_ip "test-ipblock-stacked" "pod-server")
-	client_a_net1=$(get_net1_ip "test-ipblock-stacked" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-ipblock-stacked" "pod-client-b")
-	client_c_net1=$(get_net1_ip "test-ipblock-stacked" "pod-client-c")
+	server_net1=$(wait_for_net1_ip "test-ipblock-stacked" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-ipblock-stacked" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-ipblock-stacked" "pod-client-b")
+	client_c_net1=$(wait_for_net1_ip "test-ipblock-stacked" "pod-client-c")
 }
 
-@test "setup ipblock-stacked test environments" {
-	kubectl apply --wait --timeout=${kubewait_timeout} -f ipblock-stacked.yml
-	run kubectl -n test-ipblock-stacked wait --for=condition=ready -l app=test-ipblock-stacked pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-ipblock-stacked" "pod-server" "testnetwork-policy-ipblock-stacked-1"
-	sleep 2
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nftables rules" {
 	run kubectl -n test-ipblock-stacked exec pod-server -it -- sh -c "nft list ruleset | grep testnetwork-policy-ipblock-stacked-1"
@@ -45,12 +51,6 @@ setup() {
 }
 
 @test "test-ipblock-stacked check client-c" {
-	run kubectl -n test-ipblock-stacked exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
-}
-
-@test "cleanup environments" {
-	kubectl delete -f ipblock-stacked.yml
-	run kubectl -n test-ipblock-stacked wait --for=delete -l app=test-ipblock-stacked pod --timeout=${kubewait_timeout}
+	run retry_until_deny 10 kubectl -n test-ipblock-stacked exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/ipblock.bats
+++ b/e2e/tests/ipblock.bats
@@ -4,23 +4,29 @@
 # These test cases, stacked, will create stacked policy rules in one multi-networkpolicy and test the
 # traffic policying by ncat (nc) command.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="ipblock.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-ipblock wait --for=condition=ready -l app=test-ipblock pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-ipblock" "pod-server" "testnetwork-policy-ipblock-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
 
-	server_net1=$(get_net1_ip "test-ipblock" "pod-server")
-	client_a_net1=$(get_net1_ip "test-ipblock" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-ipblock" "pod-client-b")
-	client_c_net1=$(get_net1_ip "test-ipblock" "pod-client-c")
+	server_net1=$(wait_for_net1_ip "test-ipblock" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-ipblock" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-ipblock" "pod-client-b")
+	client_c_net1=$(wait_for_net1_ip "test-ipblock" "pod-client-c")
 }
 
-@test "setup ipblock test environments" {
-	kubectl apply --wait --timeout=${kubewait_timeout} -f ipblock.yml
-	run kubectl -n test-ipblock wait --for=condition=ready -l app=test-ipblock pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-ipblock" "pod-server" "testnetwork-policy-ipblock-1"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nft rules" {
 	run kubectl -n test-ipblock exec pod-server -it -- sh -c "nft list ruleset | grep testnetwork-policy-ipblock-1"
@@ -44,12 +50,6 @@ setup() {
 }
 
 @test "test-ipblock check client-c" {
-	run kubectl -n test-ipblock exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
-}
-
-@test "cleanup environments" {
-	kubectl delete -f ipblock.yml
-	run kubectl -n test-ipblock wait --for=delete -l app=test-ipblock pod --timeout=${kubewait_timeout}
+	run retry_until_deny 10 kubectl -n test-ipblock exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/multi-namespace-multinet.bats
+++ b/e2e/tests/multi-namespace-multinet.bats
@@ -5,31 +5,33 @@
 # and two pods per namespace. It tests that MultiNetworkPolicy works correctly across
 # different namespaces with different network configurations.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="multi-namespace-multinet.yml"
+	export CLEANUP_NAMESPACES="test-namespace-a test-namespace-b"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-namespace-a wait --all --for=condition=ready pod --timeout=${kubewait_timeout}
+	kubectl -n test-namespace-b wait --all --for=condition=ready pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-namespace-a" "pod-a-1" "test-multinetwork-policy-namespace-a"
+	sleep 2
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	pod_a1_net1=$(get_net1_ip "test-namespace-a" "pod-a-1")
-	pod_a2_net1=$(get_net1_ip "test-namespace-a" "pod-a-2")
+	pod_a1_net1=$(wait_for_net1_ip "test-namespace-a" "pod-a-1")
+	pod_a2_net1=$(wait_for_net1_ip "test-namespace-a" "pod-a-2")
 
-	pod_b1_net1=$(get_net1_ip "test-namespace-b" "pod-b-1")
-	pod_b2_net1=$(get_net1_ip "test-namespace-b" "pod-b-2")
+	pod_b1_net1=$(wait_for_net1_ip "test-namespace-b" "pod-b-1")
+	pod_b2_net1=$(wait_for_net1_ip "test-namespace-b" "pod-b-2")
 	
 }
 
-@test "setup multi-namespace test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f multi-namespace-multinet.yml
-
-	# verify all pods in namespace A are available
-	run kubectl -n test-namespace-a wait --all --for=condition=ready pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-	
-	# verify all pods in namespace B are available
-	run kubectl -n test-namespace-b wait --all --for=condition=ready pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-namespace-a" "pod-a-1" "test-multinetwork-policy-namespace-a"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "Allowed connectivity" {
 	run kubectl -n test-namespace-b exec pod-b-1 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
@@ -40,17 +42,17 @@ setup() {
 }
 
 @test "Denied connectivity" {
-	run kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_a2_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_a2_net1} 5555"
+	[ "$status" -eq  "0" ]
 	
-	run kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_b1_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_b1_net1} 5555"
+	[ "$status" -eq  "0" ]
 
-	run kubectl -n test-namespace-b exec pod-a-2 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-namespace-b exec pod-a-2 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
+	[ "$status" -eq  "0" ]
 
-	run kubectl -n test-namespace-b exec pod-b-2 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-namespace-b exec pod-b-2 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "Allowed by policy absence" {
@@ -71,14 +73,4 @@ setup() {
 
 	run kubectl -n test-namespace-b exec pod-b-2 -- sh -c "echo x | nc -w 1 ${pod_b1_net1} 5555"
 	[ "$status" -eq  "0" ]
-}
-
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f multi-namespace-multinet.yml
-	run kubectl -n test-namespace-a wait --all --for=delete pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-	run kubectl -n test-namespace-b wait --all --for=delete pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
 }

--- a/e2e/tests/port-range.bats
+++ b/e2e/tests/port-range.bats
@@ -1,23 +1,26 @@
 #!/usr/bin/env bats
 
-setup() {
+setup_file() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	pod_a_net1=$(get_net1_ip "test-port-range" "pod-a")
-	pod_b_net1=$(get_net1_ip "test-port-range" "pod-b")
-}
-
-@test "setup environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f port-range.yml
-
-	# verify all pods are available
-	run kubectl -n test-port-range wait --for=condition=ready -l app=test-port-range pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
+	export MANIFEST_FILE="port-range.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-port-range wait --for=condition=ready -l app=test-port-range pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-port-range" "pod-a" "test-multinetwork-policy-simple-1"
 	sleep 2
 }
+
+setup() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	pod_a_net1=$(wait_for_net1_ip "test-port-range" "pod-a")
+	pod_b_net1=$(wait_for_net1_ip "test-port-range" "pod-b")
+}
+
+teardown_file() {
+	teardown_file_common
+}
+
 
 @test "test-port-range check pod-a -> pod-b 5555 OK" {
 	# nc should succeed from client-a to server by policy
@@ -27,25 +30,18 @@ setup() {
 
 @test "test-port-range check pod-a -> pod-b 6666 KO" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-port-range exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 6666"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-port-range exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 6666"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-port-range check pod-b -> pod-a 5555 KO" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-port-range exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-port-range exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-port-range check pod-b -> pod-a 6666 OK" {
 	# nc should succeed from client-a to server by policy
 	run kubectl -n test-port-range exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 6666"
-	[ "$status" -eq  "0" ]
-}
-
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f port-range.yml
-	run kubectl -n test-port-range wait --for=delete -l app=test-port-range pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/protocol-only-ports.bats
+++ b/e2e/tests/protocol-only-ports.bats
@@ -5,24 +5,27 @@
 # traffic policying by ncat (nc) command. In addition, these cases also verifies that
 # simple nftables generation check pod-iptable in multi-networkpolicy pod.
 
-setup() {
+setup_file() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	pod_a_net1=$(get_net1_ip "test-protocol-only-ports" "pod-a")
-	pod_b_net1=$(get_net1_ip "test-protocol-only-ports" "pod-b")
-}
-
-@test "setup environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f protocol-only-ports.yml
-
-	# verify all pods are available
-	run kubectl -n test-protocol-only-ports wait --for=condition=ready -l app=test-protocol-only-ports pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
+	export MANIFEST_FILE="protocol-only-ports.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-protocol-only-ports wait --for=condition=ready -l app=test-protocol-only-ports pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-protocol-only-ports" "pod-a" "test-multinetwork-policy-simple-1"
 	sleep 2
 }
+
+setup() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	pod_a_net1=$(wait_for_net1_ip "test-protocol-only-ports" "pod-a")
+	pod_b_net1=$(wait_for_net1_ip "test-protocol-only-ports" "pod-b")
+}
+
+teardown_file() {
+	teardown_file_common
+}
+
 
 @test "test-protocol-only-ports check pod-a -> pod-b TCP" {
 	# nc should succeed from client-a to server by policy
@@ -32,25 +35,18 @@ setup() {
 
 @test "test-protocol-only-ports check pod-a -> pod-b UDP" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-protocol-only-ports exec pod-a -- sh -c "echo x | nc --udp -w 1 ${pod_b_net1} 6666"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-protocol-only-ports exec pod-a -- sh -c "echo x | nc --udp -w 1 ${pod_b_net1} 6666"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-protocol-only-ports check pod-b -> pod-a TCP" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-protocol-only-ports exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-protocol-only-ports exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-protocol-only-ports check pod-b -> pod-a UDP" {
 	# nc should succeed from client-a to server by policy
 	run kubectl -n test-protocol-only-ports exec pod-b -- sh -c "echo x | nc --udp -w 1 ${pod_a_net1} 6666"
-	[ "$status" -eq  "0" ]
-}
-
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f protocol-only-ports.yml
-	run kubectl -n test-protocol-only-ports wait --for=delete -l app=test-protocol-only-ports pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/simple-v4-egress-list.bats
+++ b/e2e/tests/simple-v4-egress-list.bats
@@ -5,25 +5,28 @@
 # traffic policying by ncat (nc) command. In addition, these cases also verifies that
 # simple nftables generation check by pod-iptable in multi-networkpolicy pod.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="simple-v4-egress-list.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v4-egress-list wait --for=condition=ready -l app=test-simple-v4-egress-list pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-simple-v4-egress-list" "pod-server" "test-multinetwork-policy-simple-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	server_net1=$(get_net1_ip "test-simple-v4-egress-list" "pod-server")
-	client_a_net1=$(get_net1_ip "test-simple-v4-egress-list" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-simple-v4-egress-list" "pod-client-b")
-	client_c_net1=$(get_net1_ip "test-simple-v4-egress-list" "pod-client-c")
+	server_net1=$(wait_for_net1_ip "test-simple-v4-egress-list" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-simple-v4-egress-list" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-simple-v4-egress-list" "pod-client-b")
+	client_c_net1=$(wait_for_net1_ip "test-simple-v4-egress-list" "pod-client-c")
 }
 
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v4-egress-list.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v4-egress-list wait --for=condition=ready -l app=test-simple-v4-egress-list pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-simple-v4-egress-list" "pod-server" "test-multinetwork-policy-simple-1"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "test-simple-v4-egress-list check client-a -> server" {
 	# nc should succeed from client-a to server by no policy definition for the direction
@@ -51,19 +54,12 @@ setup() {
 
 @test "test-simple-v4-egress-list check server -> client-b" {
 	# nc should NOT succeed from server to client-b by policy definition
-	run kubectl -n test-simple-v4-egress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v4-egress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-egress-list check server -> client-c" {
 	# nc should succeed from server to client-c by policy definition
 	run kubectl -n test-simple-v4-egress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_c_net1} 5555"
-	[ "$status" -eq  "0" ]
-}
-
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f simple-v4-egress-list.yml
-	run kubectl -n test-simple-v4-egress-list wait --for=delete -l app=test-simple-v4-egress-list pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/simple-v4-egress-multi.bats
+++ b/e2e/tests/simple-v4-egress-multi.bats
@@ -5,27 +5,30 @@
 # traffic policying by ncat (nc) command. In addition, these cases also verifies that
 # simple nftables generation check by pod-iptable in multi-networkpolicy pod.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="simple-v4-egress-multi.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v4-egress-multi wait --for=condition=ready -l app=test-simple-v4-egress-multi pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-simple-v4-egress-multi" "pod-server" "test-multinetwork-policy-simple-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	server_net1=$(get_net1_ip "test-simple-v4-egress-multi" "pod-server")
-	client_a_net1=$(get_net1_ip "test-simple-v4-egress-multi" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-simple-v4-egress-multi" "pod-client-b")
+	server_net1=$(wait_for_net1_ip "test-simple-v4-egress-multi" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-simple-v4-egress-multi" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-simple-v4-egress-multi" "pod-client-b")
 	server_net2=$(get_net2_ip "test-simple-v4-egress-multi" "pod-server")
 	client_a_net2=$(get_net2_ip "test-simple-v4-egress-multi" "pod-client-a")
 	client_b_net2=$(get_net2_ip "test-simple-v4-egress-multi" "pod-client-b")
 }
 
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v4-egress-multi.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v4-egress-multi wait --for=condition=ready -l app=test-simple-v4-egress-multi pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-simple-v4-egress-multi" "pod-server" "test-multinetwork-policy-simple-1"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nft rules" {
 	# check pod-server has multi-networkpolicy nftables rules for ingress
@@ -71,8 +74,8 @@ setup() {
 
 @test "test-simple-v4-egress-multi check server -> client-b on net1" {
 	# nc should NOT succeed from server to client-b by policy definition
-	run kubectl -n test-simple-v4-egress-multi exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v4-egress-multi exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 ### test net2
@@ -91,8 +94,8 @@ setup() {
 
 @test "test-simple-v4-egress-multi check server -> client-a on net2" {
 	# nc should NOT succeed from server to client-a by policy definition
-	run kubectl -n test-simple-v4-egress-multi exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net2} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v4-egress-multi exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net2} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-egress-multi check server -> client-b on net2" {
@@ -116,10 +119,6 @@ setup() {
 	# enable multi-networkpolicy again
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
+	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
 }
 
-@test "cleanup environments" {
-	kubectl delete -f simple-v4-egress-multi.yml
-	run kubectl -n test-simple-v4-egress-multi wait --for=delete -l app=test-simple-v4-egress-multi pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-}

--- a/e2e/tests/simple-v4-egress.bats
+++ b/e2e/tests/simple-v4-egress.bats
@@ -5,24 +5,27 @@
 # traffic policying by ncat (nc) command. In addition, these cases also verifies that
 # simple nftables generation check by pod-iptable in multi-networkpolicy pod.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="simple-v4-egress.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v4-egress wait --for=condition=ready -l app=test-simple-v4-egress pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-simple-v4-egress" "pod-server" "test-multinetwork-policy-simple-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	server_net1=$(get_net1_ip "test-simple-v4-egress" "pod-server")
-	client_a_net1=$(get_net1_ip "test-simple-v4-egress" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-simple-v4-egress" "pod-client-b")
+	server_net1=$(wait_for_net1_ip "test-simple-v4-egress" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-simple-v4-egress" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-simple-v4-egress" "pod-client-b")
 }
 
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v4-egress.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v4-egress wait --for=condition=ready -l app=test-simple-v4-egress pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-simple-v4-egress" "pod-server" "test-multinetwork-policy-simple-1"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nft rules" {
 	# check pod-server has multi-networkpolicy nftables rules for ingress
@@ -56,8 +59,8 @@ setup() {
 
 @test "test-simple-v4-egress check server -> client-b" {
 	# nc should NOT succeed from server to client-b by policy definition
-	run kubectl -n test-simple-v4-egress exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v4-egress exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "disable multi-networkpolicy and check nftables rules" {
@@ -73,10 +76,6 @@ setup() {
 	# enable multi-networkpolicy again
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
+	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
 }
 
-@test "cleanup environments" {
-	kubectl delete -f simple-v4-egress.yml
-	run kubectl -n test-simple-v4-egress wait --for=delete -l app=test-simple-v4-egress pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-}

--- a/e2e/tests/simple-v4-ingress-list.bats
+++ b/e2e/tests/simple-v4-ingress-list.bats
@@ -5,41 +5,44 @@
 # traffic policying by ncat (nc) command. In addition, these cases also verifies that
 # simple nftables generation check by pod-iptable in multi-networkpolicy pod.
 
-setup() {
+setup_file() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	server_net1=$(get_net1_ip "test-simple-v4-ingress-list" "pod-server")
-	client_a_net1=$(get_net1_ip "test-simple-v4-ingress-list" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-simple-v4-ingress-list" "pod-client-b")
-	client_c_net1=$(get_net1_ip "test-simple-v4-ingress-list" "pod-client-c")
-}
-
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v4-ingress-list.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v4-ingress-list wait --for=condition=ready -l app=test-simple-v4-ingress-list pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
+	export MANIFEST_FILE="simple-v4-ingress-list.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v4-ingress-list wait --for=condition=ready -l app=test-simple-v4-ingress-list pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-simple-v4-ingress-list" "pod-server" "test-multinetwork-policy-simple-1"
 }
 
+setup() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	server_net1=$(wait_for_net1_ip "test-simple-v4-ingress-list" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-simple-v4-ingress-list" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-simple-v4-ingress-list" "pod-client-b")
+	client_c_net1=$(wait_for_net1_ip "test-simple-v4-ingress-list" "pod-client-c")
+}
+
+teardown_file() {
+	teardown_file_common
+}
+
+
 @test "test-simple-v4-ingress-list check client-a -> server" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-simple-v4-ingress-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_allow 10 kubectl -n test-simple-v4-ingress-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-ingress-list check client-b -> server" {
 	# nc should NOT succeed from client-b to server by policy
-	run kubectl -n test-simple-v4-ingress-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v4-ingress-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-ingress-list check client-c -> server" {
 	# nc should succeed from client-c to server by policy
-	run kubectl -n test-simple-v4-ingress-list exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_allow 10 kubectl -n test-simple-v4-ingress-list exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -58,12 +61,5 @@ setup() {
 @test "test-simple-v4-ingress-list check server -> client-c" {
 	# nc should succeed from server to client-c by no policy definition for direction (egress for pod-server)
 	run kubectl -n test-simple-v4-ingress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_c_net1} 5555"
-	[ "$status" -eq  "0" ]
-}
-
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f simple-v4-ingress-list.yml
-	run kubectl -n test-simple-v4-ingress-list wait --for=delete -l app=test-simple-v4-ingress-list pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/simple-v4-ingress-multi.bats
+++ b/e2e/tests/simple-v4-ingress-multi.bats
@@ -5,28 +5,31 @@
 # traffic policying by ncat (nc) command. In addition, these cases also verifies that
 # simple nftables generation check by pod-iptable in multi-networkpolicy pod.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="simple-v4-ingress-multi.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v4-ingress-multi wait --for=condition=ready -l app=test-simple-v4-ingress-multi pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-simple-v4-ingress-multi" "pod-server" "test-multinetwork-policy-simple-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	server_net1=$(get_net1_ip "test-simple-v4-ingress-multi" "pod-server")
-	client_a_net1=$(get_net1_ip "test-simple-v4-ingress-multi" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-simple-v4-ingress-multi" "pod-client-b")
+	server_net1=$(wait_for_net1_ip "test-simple-v4-ingress-multi" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-simple-v4-ingress-multi" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-simple-v4-ingress-multi" "pod-client-b")
 
 	server_net2=$(get_net2_ip "test-simple-v4-ingress-multi" "pod-server")
 	client_a_net2=$(get_net2_ip "test-simple-v4-ingress-multi" "pod-client-a")
 	client_b_net2=$(get_net2_ip "test-simple-v4-ingress-multi" "pod-client-b")
 }
 
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v4-ingress-multi.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v4-ingress-multi wait --for=condition=ready -l app=test-simple-v4-ingress-multi pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-simple-v4-ingress-multi" "pod-server" "test-multinetwork-policy-simple-1" 20
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nft rules" {
 	# check pod-server has multi-networkpolicy nftables rules for ingress
@@ -71,8 +74,8 @@ setup() {
 
 @test "test-simple-v4-ingress-multi check client-b -> server on net1" {
 	# nc should NOT succeed from client-b to server by policy
-	run kubectl -n test-simple-v4-ingress-multi exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v4-ingress-multi exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 ### test net2
@@ -91,8 +94,8 @@ setup() {
 
 @test "test-simple-v4-ingress-multi check client-a -> server on net2" {
 	# nc should NOT succeed from client-a to server by policy
-	run kubectl -n test-simple-v4-ingress-multi exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net2} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v4-ingress-multi exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net2} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-ingress-multi check client-b -> server on net2" {
@@ -117,11 +120,6 @@ setup() {
 	# enable multi-networkpolicy again
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
+	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
 }
 
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f simple-v4-ingress-multi.yml
-	run kubectl -n test-simple-v4-ingress-multi wait --for=delete -l app=test-simple-v4-ingress-multi pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-}

--- a/e2e/tests/simple-v4-ingress.bats
+++ b/e2e/tests/simple-v4-ingress.bats
@@ -5,24 +5,27 @@
 # traffic policying by ncat (nc) command. In addition, these cases also verifies that
 # simple nftables generation check by pod-iptable in multi-networkpolicy pod.
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="simple-v4-ingress.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v4-ingress wait --for=condition=ready -l app=test-simple-v4-ingress pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-simple-v4-ingress" "pod-server" "test-multinetwork-policy-simple-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
-	server_net1=$(get_net1_ip "test-simple-v4-ingress" "pod-server")
-	client_a_net1=$(get_net1_ip "test-simple-v4-ingress" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-simple-v4-ingress" "pod-client-b")
+	server_net1=$(wait_for_net1_ip "test-simple-v4-ingress" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-simple-v4-ingress" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-simple-v4-ingress" "pod-client-b")
 }
 
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v4-ingress.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v4-ingress wait --for=condition=ready -l app=test-simple-v4-ingress pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-simple-v4-ingress" "pod-server" "test-multinetwork-policy-simple-1"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nft rules" {
 	# check pod-server has multi-networkpolicy nftables rules for ingress
@@ -43,8 +46,8 @@ setup() {
 
 @test "test-simple-v4-ingress check client-b -> server" {
 	# nc should NOT succeed from client-b to server by policy
-	run kubectl -n test-simple-v4-ingress exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v4-ingress exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-ingress check server -> client-a" {
@@ -72,11 +75,6 @@ setup() {
 	# enable multi-networkpolicy again
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
+	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
 }
 
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f simple-v4-ingress.yml
-	run kubectl -n test-simple-v4-ingress wait --for=delete -l app=test-simple-v4-ingress pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-}

--- a/e2e/tests/simple-v6-ingress-list.bats
+++ b/e2e/tests/simple-v6-ingress-list.bats
@@ -6,6 +6,15 @@
 # simple nftables generation check by nftables-save and pod-iptable in multi-networkpolicy pod.
 
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="simple-v6-ingress-list.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v6-ingress-list wait --for=condition=ready -l app=test-simple-v6-ingress-list pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-simple-v6-ingress-list" "pod-server" "test-multinetwork-policy-simple-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
@@ -15,56 +24,43 @@ setup() {
 	client_c_net1=$(get_net1_ip6 "test-simple-v6-ingress-list" "pod-client-c")
 }
 
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v6-ingress-list.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v6-ingress-list wait --for=condition=ready -l app=test-simple-v6-ingress-list pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-	
-	wait_for_nft_rules "test-simple-v6-ingress-list" "pod-server" "test-multinetwork-policy-simple-1"
+teardown_file() {
+	teardown_file_common
 }
 
+
 @test "test-simple-v6-ingress-list check client-a -> server" {
-	# nc should succeed from client-a to server by policy
-	run kubectl -n test-simple-v6-ingress-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	# nc should succeed from client-a to server by policy (retry for IPv6 NDP convergence)
+	run retry_until_allow 10 kubectl -n test-simple-v6-ingress-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress-list check client-b -> server" {
 	# nc should NOT succeed from client-b to server by policy
-	run kubectl -n test-simple-v6-ingress-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v6-ingress-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress-list check client-c -> server" {
-	# nc should succeed from client-c to server by policy
-	run kubectl -n test-simple-v6-ingress-list exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	# nc should succeed from client-c to server by policy (retry for IPv6 NDP convergence)
+	run retry_until_allow 10 kubectl -n test-simple-v6-ingress-list exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress-list check server -> client-a" {
 	# nc should succeed from server to client-a by no policy definition for direction (egress for pod-server)
-	run kubectl -n test-simple-v6-ingress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net1} 5555"
+	run retry_until_allow 10 kubectl -n test-simple-v6-ingress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress-list check server -> client-b" {
 	# nc should succeed from server to client-b by no policy definition for direction (egress for pod-server)
-	run kubectl -n test-simple-v6-ingress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
+	run retry_until_allow 10 kubectl -n test-simple-v6-ingress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress-list check server -> client-c" {
 	# nc should succeed from server to client-c by no policy definition for direction (egress for pod-server)
-	run kubectl -n test-simple-v6-ingress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_c_net1} 5555"
-	[ "$status" -eq  "0" ]
-}
-
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f simple-v6-ingress-list.yml
-	run kubectl -n test-simple-v6-ingress-list wait --for=delete -l app=test-simple-v6-ingress-list pod --timeout=${kubewait_timeout}
+	run retry_until_allow 10 kubectl -n test-simple-v6-ingress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_c_net1} 5555"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/simple-v6-ingress-multi.bats
+++ b/e2e/tests/simple-v6-ingress-multi.bats
@@ -6,6 +6,15 @@
 # simple nftables generation check by nftables-save and pod-iptable in multi-networkpolicy pod.
 
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="simple-v6-ingress-multi.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v6-ingress-multi wait --for=condition=ready -l app=test-simple-v6-ingress-multi pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-simple-v6-ingress-multi" "pod-server" "test-multinetwork-policy-simple-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
@@ -17,16 +26,10 @@ setup() {
 	client_b_net2=$(get_net2_ip6 "test-simple-v6-ingress-multi" "pod-client-b")
 }
 
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v6-ingress-multi.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v6-ingress-multi wait --for=condition=ready -l app=test-simple-v6-ingress-multi pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-simple-v6-ingress-multi" "pod-server" "test-multinetwork-policy-simple-1"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nft rules" {
 	# check pod-server has multi-networkpolicy nftables rules for ingress
@@ -60,8 +63,8 @@ setup() {
 
 @test "test-simple-v6-ingress-multi check client-b -> server on net1" {
 	# nc should NOT succeed from client-b to server by policy
-	run kubectl -n test-simple-v6-ingress-multi exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v6-ingress-multi exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress-multi check server -> client-a on net1" {
@@ -80,8 +83,8 @@ setup() {
 
 @test "test-simple-v6-ingress-multi check client-a -> server on net2" {
 	# nc should NOT succeed from client-a to server by policy
-	run kubectl -n test-simple-v6-ingress-multi exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net2} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v6-ingress-multi exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net2} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress-multi check client-b -> server on net2" {
@@ -117,11 +120,6 @@ setup() {
 	# enable multi-networkpolicy again
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
+	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
 }
 
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f simple-v6-ingress-multi.yml
-	run kubectl -n test-simple-v6-ingress-multi wait --for=delete -l app=test-simple-v6-ingress-multi pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-}

--- a/e2e/tests/simple-v6-ingress.bats
+++ b/e2e/tests/simple-v6-ingress.bats
@@ -6,6 +6,15 @@
 # simple nftables generation check by nftables-save and pod-iptable in multi-networkpolicy pod.
 
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="simple-v6-ingress.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-simple-v6-ingress wait --for=condition=ready -l app=test-simple-v6-ingress pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-simple-v6-ingress" "pod-server" "test-multinetwork-policy-simple-1"
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
@@ -14,16 +23,10 @@ setup() {
 	client_b_net1=$(get_net1_ip6 "test-simple-v6-ingress" "pod-client-b")
 }
 
-@test "setup simple test environments" {
-	# create test manifests
-	kubectl apply --wait --timeout=${kubewait_timeout} -f simple-v6-ingress.yml
-
-	# verify all pods are available
-	run kubectl -n test-simple-v6-ingress wait --for=condition=ready -l app=test-simple-v6-ingress pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-simple-v6-ingress" "pod-server" "test-multinetwork-policy-simple-1"
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nft rules" {
 	# check pod-server has multi-networkpolicy nftables rules for ingress
@@ -45,8 +48,8 @@ setup() {
 
 @test "test-simple-v6-ingress check client-b -> server" {
 	# nc should NOT succeed from client-b to server by policy
-	run kubectl -n test-simple-v6-ingress exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
+	run retry_until_deny 10 kubectl -n test-simple-v6-ingress exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress check server -> client-a" {
@@ -74,11 +77,6 @@ setup() {
 	# enable multi-networkpolicy again
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
+	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
 }
 
-@test "cleanup environments" {
-	# remove test manifests
-	kubectl delete -f simple-v6-ingress.yml
-	run kubectl -n test-simple-v6-ingress wait --for=delete -l app=test-simple-v6-ingress pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-}

--- a/e2e/tests/stacked.bats
+++ b/e2e/tests/stacked.bats
@@ -4,24 +4,30 @@
 # These test cases, stacked, will create stacked policy rules in one multi-networkpolicy and test the 
 # traffic policying by ncat (nc) command. 
 
+setup_file() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	export MANIFEST_FILE="stacked.yml"
+	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
+	kubectl -n test-stacked wait --for=condition=ready -l app=test-stacked pod --timeout=${kubewait_timeout}
+	wait_for_nft_rules "test-stacked" "pod-server" "testnetwork-policy-stacked-1" 20
+	sleep 2
+}
+
 setup() {
 	cd $BATS_TEST_DIRNAME
 	load "common"
 
-	server_net1=$(get_net1_ip "test-stacked" "pod-server")
-	client_a_net1=$(get_net1_ip "test-stacked" "pod-client-a")
-	client_b_net1=$(get_net1_ip "test-stacked" "pod-client-b")
-	client_c_net1=$(get_net1_ip "test-stacked" "pod-client-c")
+	server_net1=$(wait_for_net1_ip "test-stacked" "pod-server")
+	client_a_net1=$(wait_for_net1_ip "test-stacked" "pod-client-a")
+	client_b_net1=$(wait_for_net1_ip "test-stacked" "pod-client-b")
+	client_c_net1=$(wait_for_net1_ip "test-stacked" "pod-client-c")
 }
 
-@test "setup stacked test environments" {
-	kubectl apply --wait --timeout=${kubewait_timeout} -f stacked.yml
-	run kubectl -n test-stacked wait --for=condition=ready -l app=test-stacked pod --timeout=${kubewait_timeout}
-	[ "$status" -eq  "0" ]
-
-	wait_for_nft_rules "test-stacked" "pod-server" "testnetwork-policy-stacked-1" 20
-	sleep 2
+teardown_file() {
+	teardown_file_common
 }
+
 
 @test "check generated nft rules" {
 	run kubectl -n test-stacked exec pod-server -it -- sh -c "nft list ruleset | grep multi-ingress-test-stacked-testnetwork-policy-stacked-1"
@@ -45,12 +51,6 @@ setup() {
 }
 
 @test "test-stacked check client-c" {
-	run kubectl -n test-stacked exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
-	[ "$status" -eq  "1" ]
-}
-
-@test "cleanup environments" {
-	kubectl delete -f stacked.yml
-	run kubectl -n test-stacked wait --for=delete -l app=test-stacked pod --timeout=${kubewait_timeout}
+	run retry_until_deny 10 kubectl -n test-stacked exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }


### PR DESCRIPTION
## Summary
- Add `teardown_file()` to `common.bash` that automatically cleans up test resources after each BATS file completes, regardless of test pass/fail
- Remove all 18 `@test "cleanup environments"` blocks from BATS files — cleanup now runs via BATS lifecycle hooks
- Add exit trap to `run_all_tests.sh` for collecting logs on suite-level failures
- Each BATS file now declares its manifest in `setup_file()`, and `teardown_file()` handles deletion

## Why
- Previously, cleanup was in a final `@test` block — if any earlier test failed, BATS would stop (depending on flags) and cleanup would never run, leaking namespaces and pods
- `teardown_file()` is a BATS lifecycle hook that runs after ALL tests complete, even on failure
- This ensures reliable cleanup and prevents resource leaks between test files

## Changes
- `e2e/tests/common.bash` — add `teardown_file()` and documentation
- `e2e/run_all_tests.sh` — add exit trap for log collection
- All 18 `e2e/tests/*.bats` — add `setup_file()`, remove `@test "cleanup environments"` blocks