### PR TITLE
chore: add Apache-2.0 license headers to files missing them

### DIFF
--- a/pkg/nftest/nftest.go
+++ b/pkg/nftest/nftest.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Deutsche Telekom AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package nftest contains utility functions for nftables testing.
 package nftest
 

--- a/pkg/nftest/system_conn.go
+++ b/pkg/nftest/system_conn.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Deutsche Telekom AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package nftest
 
 import (

--- a/pkg/server/encoder.go
+++ b/pkg/server/encoder.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Deutsche Telekom AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Deutsche Telekom AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (

--- a/pkg/server/netfilterrules_test.go
+++ b/pkg/server/netfilterrules_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Deutsche Telekom AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (


### PR DESCRIPTION
## Summary
- Add Apache-2.0 license headers to 5 Go files that were missing them
- Uses the same header format as all other Go files in the project (Copyright 2020 The Kubernetes Authors)

## Files Updated
- `pkg/nftest/nftest.go`
- `pkg/nftest/system_conn.go`
- `pkg/server/encoder.go`
- `pkg/server/netfilterrules.go`
- `pkg/server/netfilterrules_test.go`

## Why
All other Go files in `cmd/` and `pkg/` already have this header. These 5 were missed, likely because they were added later. Consistent license headers are required for open-source compliance.