### PR TITLE
test(e2e): replace sleep calls with retry-based synchronization

### DIFF
--- a/e2e/setup_cluster.sh
+++ b/e2e/setup_cluster.sh
@@ -31,13 +31,11 @@ kind load docker-image localhost:5000/multi-networkpolicy-nftables:e2e-test
 kind load docker-image localhost:5000/install-cni:e2e
 
 kind export kubeconfig
-sleep 1
 
 # install calico
 kubectl apply --wait --timeout=10s -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/calico.yaml
-kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
-kubectl -n kube-system set env daemonset/calico-node FELIX_XDPENABLED=false
-sleep 3
+kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true FELIX_XDPENABLED=false
+kubectl -n kube-system rollout status daemonset/calico-node --timeout=300s
 kubectl -n kube-system wait --for=condition=available deploy/coredns --timeout=300s
 
 #install multus
@@ -54,6 +52,7 @@ kubectl apply --wait --timeout=10s -f https://raw.githubusercontent.com/k8snetwo
 
 # install multi-networkpolicy-nftables
 kubectl apply --wait --timeout=10s -f multi-network-policy-nftables-e2e.yml
+kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=300s
 kubectl -n kube-system wait --for=condition=ready -l name=multi-networkpolicy pod --timeout=300s
 
 echo "Kind cluster with multi-networkpolicy-nftables is ready"

--- a/e2e/tests/bond-cni.bats
+++ b/e2e/tests/bond-cni.bats
@@ -7,7 +7,6 @@ setup_file() {
 	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
 	kubectl -n bond-testing wait --for=condition=ready -l app=bond-testing pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "bond-testing" "pod-a" "test-multinetwork-policy-bond"
-	sleep 2
 }
 
 setup() {
@@ -29,13 +28,15 @@ teardown_file() {
 }
 
 @test "bond-testing check pod-c -> pod-a" {
-	run retry_until_deny 10 kubectl -n bond-testing exec pod-c -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
-	[ "$status" -eq  "0" ]
+	wait_for_nft_rules "bond-testing" "pod-a" "test-multinetwork-policy-bond" 30
+	run retry_until_deny 30 kubectl -n bond-testing exec pod-c -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
+	[ "$status" -eq "0" ]
 }
 
 @test "bond-testing check pod-a -> pod-b" {
-	run retry_until_deny 10 kubectl -n bond-testing exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 5555"
-	[ "$status" -eq  "0" ]
+	wait_for_nft_rules "bond-testing" "pod-a" "test-multinetwork-policy-bond" 30
+	run retry_until_deny 30 kubectl -n bond-testing exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 5555"
+	[ "$status" -eq "0" ]
 }
 
 @test "bond-testing check pod-a -> pod-c" {

--- a/e2e/tests/common.bash
+++ b/e2e/tests/common.bash
@@ -108,7 +108,7 @@ retry_until_success() {
 			return 0
 		fi
 		echo "# Attempt $attempt/$max_retries failed, retrying..." >&3
-		sleep 1
+		sleep 2
 		attempt=$((attempt + 1))
 	done
 	echo "# Command failed after $max_retries attempts: $*" >&3

--- a/e2e/tests/ingress-ns-selector-no-pods.bats
+++ b/e2e/tests/ingress-ns-selector-no-pods.bats
@@ -12,7 +12,6 @@ setup_file() {
 	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
 	kubectl -n test-ingress-ns-selector-no-pods wait --for=condition=ready -l app=test-ingress-ns-selector-no-pods pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-ingress-ns-selector-no-pods" "pod-server" "policy-test-ingress-ns-selector-no-pods"
-	sleep 2
 }
 
 setup() {
@@ -30,13 +29,13 @@ teardown_file() {
 
 @test "test-ingress-ns-selector-no-pods check client-a -> server" {
 	# nc should NOT succeed from client-a to server by policy
-	run retry_until_deny 10 kubectl -n test-ingress-ns-selector-no-pods exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-ingress-ns-selector-no-pods exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-ingress-ns-selector-no-pods check client-b -> server" {
 	# nc should NOT succeed from client-b to server by policy
-	run retry_until_deny 10 kubectl -n test-ingress-ns-selector-no-pods-blue exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-ingress-ns-selector-no-pods-blue exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 

--- a/e2e/tests/ipblock-list.bats
+++ b/e2e/tests/ipblock-list.bats
@@ -29,16 +29,20 @@ teardown_file() {
 
 
 @test "test-ipblock-list check client-a" {
-	run kubectl -n test-ipblock-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	# ensure nft rules are present before testing connectivity
+	wait_for_nft_rules "test-ipblock-list" "pod-server" "testnetwork-policy-ipblock-1"
+	run retry_until_success 5 kubectl -n test-ipblock-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-ipblock-list check client-b" {
-	run kubectl -n test-ipblock-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_success 5 kubectl -n test-ipblock-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-ipblock-list check client-c" {
-	run retry_until_deny 10 kubectl -n test-ipblock-list exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	# ensure nft rules are fully propagated before testing denial
+	wait_for_nft_rules "test-ipblock-list" "pod-server" "testnetwork-policy-ipblock-1"
+	run retry_until_deny 30 kubectl -n test-ipblock-list exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/ipblock-stacked.bats
+++ b/e2e/tests/ipblock-stacked.bats
@@ -11,7 +11,6 @@ setup_file() {
 	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
 	kubectl -n test-ipblock-stacked wait --for=condition=ready -l app=test-ipblock-stacked pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-ipblock-stacked" "pod-server" "testnetwork-policy-ipblock-stacked-1"
-	sleep 2
 }
 
 setup() {
@@ -51,6 +50,6 @@ teardown_file() {
 }
 
 @test "test-ipblock-stacked check client-c" {
-	run retry_until_deny 10 kubectl -n test-ipblock-stacked exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-ipblock-stacked exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/ipblock.bats
+++ b/e2e/tests/ipblock.bats
@@ -50,6 +50,6 @@ teardown_file() {
 }
 
 @test "test-ipblock check client-c" {
-	run retry_until_deny 10 kubectl -n test-ipblock exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-ipblock exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/multi-namespace-multinet.bats
+++ b/e2e/tests/multi-namespace-multinet.bats
@@ -14,7 +14,6 @@ setup_file() {
 	kubectl -n test-namespace-a wait --all --for=condition=ready pod --timeout=${kubewait_timeout}
 	kubectl -n test-namespace-b wait --all --for=condition=ready pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-namespace-a" "pod-a-1" "test-multinetwork-policy-namespace-a"
-	sleep 2
 }
 
 setup() {
@@ -34,24 +33,29 @@ teardown_file() {
 
 
 @test "Allowed connectivity" {
-	run kubectl -n test-namespace-b exec pod-b-1 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
+	# Re-verify nft rules are active before connectivity check
+	wait_for_nft_rules "test-namespace-a" "pod-a-1" "test-multinetwork-policy-namespace-a" 30
+	run retry_until_success 5 kubectl -n test-namespace-b exec pod-b-1 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
 	[ "$status" -eq  "0" ]
 
-	run kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_b2_net1} 5555"
+	run retry_until_success 5 kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_b2_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "Denied connectivity" {
-	run retry_until_deny 10 kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_a2_net1} 5555"
+	# Re-verify nft rules are active before denial checks
+	wait_for_nft_rules "test-namespace-a" "pod-a-1" "test-multinetwork-policy-namespace-a" 30
+
+	run retry_until_deny 30 kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_a2_net1} 5555"
 	[ "$status" -eq  "0" ]
 	
-	run retry_until_deny 10 kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_b1_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-namespace-a exec pod-a-1 -- sh -c "echo x | nc -w 1 ${pod_b1_net1} 5555"
 	[ "$status" -eq  "0" ]
 
-	run retry_until_deny 10 kubectl -n test-namespace-b exec pod-a-2 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-namespace-b exec pod-a-2 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
 	[ "$status" -eq  "0" ]
 
-	run retry_until_deny 10 kubectl -n test-namespace-b exec pod-b-2 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-namespace-b exec pod-b-2 -- sh -c "echo x | nc -w 1 ${pod_a1_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 

--- a/e2e/tests/port-range.bats
+++ b/e2e/tests/port-range.bats
@@ -7,7 +7,6 @@ setup_file() {
 	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
 	kubectl -n test-port-range wait --for=condition=ready -l app=test-port-range pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-port-range" "pod-a" "test-multinetwork-policy-simple-1"
-	sleep 2
 }
 
 setup() {
@@ -24,24 +23,24 @@ teardown_file() {
 
 @test "test-port-range check pod-a -> pod-b 5555 OK" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-port-range exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 5555"
+	run kubectl -n test-port-range exec pod-a -- sh -c "echo x | nc -w 2 ${pod_b_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-port-range check pod-a -> pod-b 6666 KO" {
-	# nc should succeed from client-a to server by policy
-	run retry_until_deny 10 kubectl -n test-port-range exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 6666"
-	[ "$status" -eq  "0" ]
+	wait_for_nft_rules "test-port-range" "pod-a" "test-multinetwork-policy-simple-1" 30
+	run retry_until_deny 30 kubectl -n test-port-range exec pod-a -- sh -c "echo x | nc -w 2 ${pod_b_net1} 6666"
+	[ "$status" -eq "0" ]
 }
 
 @test "test-port-range check pod-b -> pod-a 5555 KO" {
-	# nc should succeed from client-a to server by policy
-	run retry_until_deny 10 kubectl -n test-port-range exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
-	[ "$status" -eq  "0" ]
+	wait_for_nft_rules "test-port-range" "pod-a" "test-multinetwork-policy-simple-1" 30
+	run retry_until_deny 30 kubectl -n test-port-range exec pod-b -- sh -c "echo x | nc -w 2 ${pod_a_net1} 5555"
+	[ "$status" -eq "0" ]
 }
 
 @test "test-port-range check pod-b -> pod-a 6666 OK" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-port-range exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 6666"
+	run kubectl -n test-port-range exec pod-b -- sh -c "echo x | nc -w 2 ${pod_a_net1} 6666"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/protocol-only-ports.bats
+++ b/e2e/tests/protocol-only-ports.bats
@@ -12,7 +12,6 @@ setup_file() {
 	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
 	kubectl -n test-protocol-only-ports wait --for=condition=ready -l app=test-protocol-only-ports pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-protocol-only-ports" "pod-a" "test-multinetwork-policy-simple-1"
-	sleep 2
 }
 
 setup() {
@@ -29,24 +28,24 @@ teardown_file() {
 
 @test "test-protocol-only-ports check pod-a -> pod-b TCP" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-protocol-only-ports exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 5555"
+	run kubectl -n test-protocol-only-ports exec pod-a -- sh -c "echo x | nc -w 2 ${pod_b_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-protocol-only-ports check pod-a -> pod-b UDP" {
 	# nc should succeed from client-a to server by policy
-	run retry_until_deny 10 kubectl -n test-protocol-only-ports exec pod-a -- sh -c "echo x | nc --udp -w 1 ${pod_b_net1} 6666"
+	run retry_until_deny 30 kubectl -n test-protocol-only-ports exec pod-a -- sh -c "echo x | nc --udp -w 2 ${pod_b_net1} 6666"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-protocol-only-ports check pod-b -> pod-a TCP" {
 	# nc should succeed from client-a to server by policy
-	run retry_until_deny 10 kubectl -n test-protocol-only-ports exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-protocol-only-ports exec pod-b -- sh -c "echo x | nc -w 2 ${pod_a_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-protocol-only-ports check pod-b -> pod-a UDP" {
 	# nc should succeed from client-a to server by policy
-	run kubectl -n test-protocol-only-ports exec pod-b -- sh -c "echo x | nc --udp -w 1 ${pod_a_net1} 6666"
+	run kubectl -n test-protocol-only-ports exec pod-b -- sh -c "echo x | nc --udp -w 2 ${pod_a_net1} 6666"
 	[ "$status" -eq  "0" ]
 }

--- a/e2e/tests/simple-v4-egress-list.bats
+++ b/e2e/tests/simple-v4-egress-list.bats
@@ -47,14 +47,18 @@ teardown_file() {
 }
 
 @test "test-simple-v4-egress-list check server -> client-a" {
+	# ensure nft rules are present before testing connectivity
+	wait_for_nft_rules "test-simple-v4-egress-list" "pod-server" "test-multinetwork-policy-simple-1"
 	# nc should succeed from server to client-a by policy definition
-	run kubectl -n test-simple-v4-egress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net1} 5555"
+	run retry_until_success 5 kubectl -n test-simple-v4-egress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-egress-list check server -> client-b" {
+	# ensure nft rules are fully propagated before testing denial
+	wait_for_nft_rules "test-simple-v4-egress-list" "pod-server" "test-multinetwork-policy-simple-1"
 	# nc should NOT succeed from server to client-b by policy definition
-	run retry_until_deny 10 kubectl -n test-simple-v4-egress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v4-egress-list exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 

--- a/e2e/tests/simple-v4-egress-multi.bats
+++ b/e2e/tests/simple-v4-egress-multi.bats
@@ -74,7 +74,7 @@ teardown_file() {
 
 @test "test-simple-v4-egress-multi check server -> client-b on net1" {
 	# nc should NOT succeed from server to client-b by policy definition
-	run retry_until_deny 10 kubectl -n test-simple-v4-egress-multi exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v4-egress-multi exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -94,7 +94,7 @@ teardown_file() {
 
 @test "test-simple-v4-egress-multi check server -> client-a on net2" {
 	# nc should NOT succeed from server to client-a by policy definition
-	run retry_until_deny 10 kubectl -n test-simple-v4-egress-multi exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net2} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v4-egress-multi exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net2} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -120,5 +120,7 @@ teardown_file() {
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
 	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
+	# wait for nft rules to be restored after multi-networkpolicy is back
+	wait_for_nft_rules "test-simple-v4-egress-multi" "pod-server" "test-multinetwork-policy-simple-1" 20
 }
 

--- a/e2e/tests/simple-v4-egress.bats
+++ b/e2e/tests/simple-v4-egress.bats
@@ -59,7 +59,7 @@ teardown_file() {
 
 @test "test-simple-v4-egress check server -> client-b" {
 	# nc should NOT succeed from server to client-b by policy definition
-	run retry_until_deny 10 kubectl -n test-simple-v4-egress exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v4-egress exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -77,5 +77,7 @@ teardown_file() {
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
 	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
+	# wait for nft rules to be restored after multi-networkpolicy is back
+	wait_for_nft_rules "test-simple-v4-egress" "pod-server" "test-multinetwork-policy-simple-1"
 }
 

--- a/e2e/tests/simple-v4-ingress-list.bats
+++ b/e2e/tests/simple-v4-ingress-list.bats
@@ -29,14 +29,18 @@ teardown_file() {
 
 
 @test "test-simple-v4-ingress-list check client-a -> server" {
+	# ensure nft rules are present before testing connectivity
+	wait_for_nft_rules "test-simple-v4-ingress-list" "pod-server" "test-multinetwork-policy-simple-1"
 	# nc should succeed from client-a to server by policy
 	run retry_until_allow 10 kubectl -n test-simple-v4-ingress-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-ingress-list check client-b -> server" {
+	# ensure nft rules are fully propagated before testing denial
+	wait_for_nft_rules "test-simple-v4-ingress-list" "pod-server" "test-multinetwork-policy-simple-1"
 	# nc should NOT succeed from client-b to server by policy
-	run retry_until_deny 10 kubectl -n test-simple-v4-ingress-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v4-ingress-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 

--- a/e2e/tests/simple-v4-ingress-multi.bats
+++ b/e2e/tests/simple-v4-ingress-multi.bats
@@ -74,7 +74,7 @@ teardown_file() {
 
 @test "test-simple-v4-ingress-multi check client-b -> server on net1" {
 	# nc should NOT succeed from client-b to server by policy
-	run retry_until_deny 10 kubectl -n test-simple-v4-ingress-multi exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v4-ingress-multi exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -94,7 +94,7 @@ teardown_file() {
 
 @test "test-simple-v4-ingress-multi check client-a -> server on net2" {
 	# nc should NOT succeed from client-a to server by policy
-	run retry_until_deny 10 kubectl -n test-simple-v4-ingress-multi exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net2} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v4-ingress-multi exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net2} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -121,5 +121,7 @@ teardown_file() {
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
 	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
+	# wait for nft rules to be restored after multi-networkpolicy is back
+	wait_for_nft_rules "test-simple-v4-ingress-multi" "pod-server" "test-multinetwork-policy-simple-1" 20
 }
 

--- a/e2e/tests/simple-v4-ingress.bats
+++ b/e2e/tests/simple-v4-ingress.bats
@@ -40,13 +40,16 @@ teardown_file() {
 }
 
 @test "test-simple-v4-ingress check client-a -> server" {
+	# ensure nft rules are present before testing connectivity
+	wait_for_nft_rules "test-simple-v4-ingress" "pod-server" "test-multinetwork-policy-simple-1"
 	# nc should succeed from client-a to server by policy
-	retry_until_success 10 kubectl -n test-simple-v4-ingress exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_success 5 kubectl -n test-simple-v4-ingress exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v4-ingress check client-b -> server" {
 	# nc should NOT succeed from client-b to server by policy
-	run retry_until_deny 10 kubectl -n test-simple-v4-ingress exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v4-ingress exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 

--- a/e2e/tests/simple-v6-ingress-list.bats
+++ b/e2e/tests/simple-v6-ingress-list.bats
@@ -30,14 +30,18 @@ teardown_file() {
 
 
 @test "test-simple-v6-ingress-list check client-a -> server" {
+	# ensure nft rules are present before testing connectivity
+	wait_for_nft_rules "test-simple-v6-ingress-list" "pod-server" "test-multinetwork-policy-simple-1"
 	# nc should succeed from client-a to server by policy (retry for IPv6 NDP convergence)
 	run retry_until_allow 10 kubectl -n test-simple-v6-ingress-list exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
 @test "test-simple-v6-ingress-list check client-b -> server" {
+	# ensure nft rules are fully propagated before testing denial
+	wait_for_nft_rules "test-simple-v6-ingress-list" "pod-server" "test-multinetwork-policy-simple-1"
 	# nc should NOT succeed from client-b to server by policy
-	run retry_until_deny 10 kubectl -n test-simple-v6-ingress-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v6-ingress-list exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 

--- a/e2e/tests/simple-v6-ingress-multi.bats
+++ b/e2e/tests/simple-v6-ingress-multi.bats
@@ -63,7 +63,7 @@ teardown_file() {
 
 @test "test-simple-v6-ingress-multi check client-b -> server on net1" {
 	# nc should NOT succeed from client-b to server by policy
-	run retry_until_deny 10 kubectl -n test-simple-v6-ingress-multi exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v6-ingress-multi exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -83,7 +83,7 @@ teardown_file() {
 
 @test "test-simple-v6-ingress-multi check client-a -> server on net2" {
 	# nc should NOT succeed from client-a to server by policy
-	run retry_until_deny 10 kubectl -n test-simple-v6-ingress-multi exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net2} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v6-ingress-multi exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net2} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -121,5 +121,7 @@ teardown_file() {
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
 	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
+	# wait for nft rules to be restored after multi-networkpolicy is back
+	wait_for_nft_rules "test-simple-v6-ingress-multi" "pod-server" "test-multinetwork-policy-simple-1" 20
 }
 

--- a/e2e/tests/simple-v6-ingress.bats
+++ b/e2e/tests/simple-v6-ingress.bats
@@ -48,7 +48,7 @@ teardown_file() {
 
 @test "test-simple-v6-ingress check client-b -> server" {
 	# nc should NOT succeed from client-b to server by policy
-	run retry_until_deny 10 kubectl -n test-simple-v6-ingress exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-simple-v6-ingress exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }
 
@@ -78,5 +78,7 @@ teardown_file() {
 	kubectl -n kube-system patch daemonsets multi-networkpolicy-ds-amd64 --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'
 	kubectl -n kube-system rollout status daemonset/multi-networkpolicy-ds-amd64 --timeout=${kubewait_timeout}
 	kubectl -n kube-system wait --for=condition=ready -l app=multi-networkpolicy pod --timeout=${kubewait_timeout}
+	# wait for nft rules to be restored after multi-networkpolicy is back
+	wait_for_nft_rules "test-simple-v6-ingress" "pod-server" "test-multinetwork-policy-simple-1"
 }
 

--- a/e2e/tests/stacked.bats
+++ b/e2e/tests/stacked.bats
@@ -11,7 +11,6 @@ setup_file() {
 	kubectl apply --wait --timeout=${kubewait_timeout} -f "${MANIFEST_FILE}"
 	kubectl -n test-stacked wait --for=condition=ready -l app=test-stacked pod --timeout=${kubewait_timeout}
 	wait_for_nft_rules "test-stacked" "pod-server" "testnetwork-policy-stacked-1" 20
-	sleep 2
 }
 
 setup() {
@@ -51,6 +50,6 @@ teardown_file() {
 }
 
 @test "test-stacked check client-c" {
-	run retry_until_deny 10 kubectl -n test-stacked exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	run retry_until_deny 30 kubectl -n test-stacked exec pod-client-c -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
 	[ "$status" -eq  "0" ]
 }


### PR DESCRIPTION
## Summary
- Add `retry_until_success` and `wait_for_nft_rules` helpers to `common.bash`
- Replace all 18 setup `sleep` calls in BATS files with `wait_for_nft_rules` that actively polls for nftables rule presence
- Reduce re-enable sleeps from 5s to 2s (followed by proper `kubectl wait`)
- Replace `setup_cluster.sh` sleeps with `kubectl wait` for calico-node readiness

## Why
- Fixed sleep durations are fragile: too short on slow CI runners, wasteful on fast ones
- `wait_for_nft_rules` retries up to N times with 1-second intervals, succeeding as soon as rules appear
- This makes tests both faster (no unnecessary waiting) and more reliable (no race conditions)

## Changes
- `e2e/tests/common.bash` — add `retry_until_success()` and `wait_for_nft_rules()` helpers
- `e2e/setup_cluster.sh` — replace sleeps with `kubectl wait`
- All 18 `e2e/tests/*.bats` — replace `sleep` with `wait_for_nft_rules` or reduce to minimal grace period