### PR TITLE
test(e2e): add JUnit XML reporting for test results

### DIFF
--- a/.github/workflows/kind-e2e.yml
+++ b/.github/workflows/kind-e2e.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   e2e-kind:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - name: Install bats
         run: sudo apt install bats
@@ -40,3 +43,23 @@ jobs:
         with:
           name: kind-logs-e2e
           path: ./e2e/artifacts/
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-test-results
+          path: ./e2e/artifacts/junit/
+          if-no-files-found: ignore
+
+      - name: Publish test report
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: always() && hashFiles('./e2e/artifacts/junit/*.xml') != ''
+        continue-on-error: true
+        with:
+          name: E2E Test Results
+          path: ./e2e/artifacts/junit/*.xml
+          reporter: java-junit
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: false
+          fail-on-empty: 'false'

--- a/.github/workflows/kind-e2e.yml
+++ b/.github/workflows/kind-e2e.yml
@@ -52,6 +52,24 @@ jobs:
           path: ./e2e/artifacts/junit/
           if-no-files-found: ignore
 
+      - name: Print test summary
+        if: always()
+        run: |
+          echo "## E2E Test Results" >> "$GITHUB_STEP_SUMMARY"
+          for f in ./e2e/artifacts/junit/*.xml; do
+            [ -f "$f" ] || continue
+            suite="$(basename "$f" .xml)"
+            tests="$(grep -o 'tests="[0-9]*"' "$f" | head -1 | grep -o '[0-9]*')"
+            failures="$(grep -o 'failures="[0-9]*"' "$f" | head -1 | grep -o '[0-9]*')"
+            errors="$(grep -o 'errors="[0-9]*"' "$f" | head -1 | grep -o '[0-9]*')"
+            skipped="$(grep -o 'skipped="[0-9]*"' "$f" | head -1 | grep -o '[0-9]*')"
+            if [ "${failures:-0}" -eq 0 ] && [ "${errors:-0}" -eq 0 ]; then
+              echo "- ✅ **${suite}**: ${tests} tests, ${skipped:-0} skipped" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "- ❌ **${suite}**: ${tests} tests, ${failures:-0} failures, ${errors:-0} errors" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
       - name: Publish test report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always() && hashFiles('./e2e/artifacts/junit/*.xml') != ''

--- a/e2e/run_all_tests.sh
+++ b/e2e/run_all_tests.sh
@@ -2,7 +2,7 @@
 
 E2E="$(dirname "$(realpath "$0")")"
 
-cd "${E2E}" || exit
+pushd "${E2E}" > /dev/null || exit
 
 suite_failed=0
 

--- a/e2e/run_all_tests.sh
+++ b/e2e/run_all_tests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-E2E="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+E2E="$(dirname "$(realpath "$0")")"
 
-pushd ${E2E}
+cd "${E2E}" || exit
 
 suite_failed=0
 
@@ -30,13 +30,25 @@ trap 'cleanup_on_exit $? EXIT' EXIT
 trap 'cleanup_on_exit $? INT' INT
 trap 'cleanup_on_exit $? TERM' TERM
 
+mkdir -p ./artifacts/junit
+
 for f in ./tests/*.bats; do
-    echo "=== Running: $(basename $f) ==="
-    bats $f
+    test_name="$(basename "$f" .bats)"
+    echo "=== Running: ${test_name} ==="
+
+    bats "$f"
     retval=$?
-    if [ $retval -ne 0 ]; then
+
+    bats_help="$(bats --help 2>&1)"
+    if printf '%s\n' "$bats_help" | grep -q -- "--report-formatter" &&
+        printf '%s\n' "$bats_help" | grep -q -- "junit"; then
+        bats --report-formatter junit --output "./artifacts/junit" "$f" || true
+    fi
+
+    if [ "$retval" -ne 0 ]; then
         suite_failed=1
-        ./bin/kind export logs ./artifacts/`basename $f`.test/kind-logs
+        kind_logs_dir="./artifacts/$(basename "$f" .bats).test/kind-logs"
+        ./bin/kind export logs "$kind_logs_dir"
     fi
 done
 

--- a/e2e/run_all_tests.sh
+++ b/e2e/run_all_tests.sh
@@ -2,7 +2,7 @@
 
 E2E="$(dirname "$(realpath "$0")")"
 
-pushd "${E2E}" > /dev/null || exit
+pushd "${E2E}"
 
 suite_failed=0
 

--- a/e2e/run_all_tests.sh
+++ b/e2e/run_all_tests.sh
@@ -36,14 +36,15 @@ for f in ./tests/*.bats; do
     test_name="$(basename "$f" .bats)"
     echo "=== Running: ${test_name} ==="
 
-    bats "$f"
-    retval=$?
-
+    # Check if bats supports JUnit reporting to avoid running tests twice
     bats_help="$(bats --help 2>&1)"
     if printf '%s\n' "$bats_help" | grep -q -- "--report-formatter" &&
         printf '%s\n' "$bats_help" | grep -q -- "junit"; then
-        bats --report-formatter junit --output "./artifacts/junit" "$f" || true
+        bats --report-formatter junit --output "./artifacts/junit" "$f"
+    else
+        bats "$f"
     fi
+    retval=$?
 
     if [ "$retval" -ne 0 ]; then
         suite_failed=1

--- a/e2e/run_all_tests.sh
+++ b/e2e/run_all_tests.sh
@@ -40,7 +40,7 @@ for f in ./tests/*.bats; do
     bats_help="$(bats --help 2>&1)"
     if printf '%s\n' "$bats_help" | grep -q -- "--report-formatter" &&
         printf '%s\n' "$bats_help" | grep -q -- "junit"; then
-        bats --report-formatter junit --output "./artifacts/junit" "$f"
+        BATS_REPORT_FILENAME="${test_name}.xml" bats --report-formatter junit --output "./artifacts/junit" "$f"
     else
         bats "$f"
     fi

--- a/e2e/tests/common.bash
+++ b/e2e/tests/common.bash
@@ -156,6 +156,7 @@ wait_for_nft_rule() {
 	return 1
 }
 
+
 # retry_until_success retries a command up to $1 times with 1-second intervals.
 # Usage: retry_until_success <max_retries> <command...>
 retry_until_success() {

--- a/e2e/tests/common.bash
+++ b/e2e/tests/common.bash
@@ -223,6 +223,21 @@ retry_until_allow() {
 	return 1
 }
 
+# wait_for_nft_rule_absent polls until the given pod no longer has an nft rule matching the pattern.
+# Usage: wait_for_nft_rule_absent <namespace> <pod> <grep-pattern> [timeout_seconds]
+# Returns non-zero if the rule is still present after the timeout.
+wait_for_nft_rule_absent() {
+	local ns="$1" pod="$2" pattern="$3" timeout="${4:-30}" attempts=0
+	while [ $attempts -lt $timeout ]; do
+		if ! kubectl -n "$ns" exec "$pod" -- sh -c "nft list ruleset 2>/dev/null | grep -q '$pattern'" 2>/dev/null; then
+			return 0
+		fi
+		sleep 1
+		attempts=$((attempts + 1))
+	done
+	return 1
+}
+
 # wait_for_nft_rules waits until nftables rules containing the given pattern appear in a pod.
 # Usage: wait_for_nft_rules <namespace> <pod> <grep_pattern> [max_retries]
 wait_for_nft_rules() {


### PR DESCRIPTION
## Summary
- Add JUnit XML test report generation to E2E test runner
- Upload JUnit results as CI artifact and publish test report via dorny/test-reporter
- Improve shell quoting and variable handling in run_all_tests.sh

## Changes
- \`.github/workflows/kind-e2e.yml\`: Add permissions for check annotations, upload JUnit artifacts, publish test report
- \`e2e/run_all_tests.sh\`: Generate JUnit XML output alongside terminal output, improve shell quoting