### PR TITLE
fix: namespaceSelector-only peers now match all pods in matched namespaces

### DIFF
--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -1171,10 +1171,20 @@ func (n *nftState) applyPolicyPeersRulesIPBlock(chainName string, chain *nftable
 
 func (n *nftState) applyPolicyPeersRulesSelector(s *Server, chainName string, chain *nftables.Chain, policyName string, peer multiv1beta1.MultiNetworkPolicyPeer,
 	podInfo *controllers.PodInfo, policyNetworks []string, peerIndex int) error {
-	klog.V(8).Infof("applying peers rules with pod selector: %s", peer.PodSelector.String())
-	podSelector, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
-	if err != nil {
-		return fmt.Errorf("pod selector: %w", err)
+	if peer.PodSelector != nil {
+		klog.V(8).Infof("applying peers rules with pod selector: %s", peer.PodSelector.String())
+	} else {
+		klog.V(8).Info("applying peers rules with namespace selector only (all pods in matched namespaces)")
+	}
+	var podSelector labels.Selector
+	if peer.PodSelector != nil {
+		var err error
+		podSelector, err = metav1.LabelSelectorAsSelector(peer.PodSelector)
+		if err != nil {
+			return fmt.Errorf("pod selector: %w", err)
+		}
+	} else {
+		podSelector = labels.Everything()
 	}
 
 	pods, err := s.podLister.Pods(metav1.NamespaceAll).List(podSelector)
@@ -1266,9 +1276,15 @@ func (n *nftState) addIPRule(chainName string, addrs []string, chain *nftables.C
 		offset += payloadLen
 	}
 
-	selectorHash, err := hash(peer.PodSelector.String())
+	var selectorStr string
+	if peer.PodSelector != nil {
+		selectorStr = peer.PodSelector.String()
+	} else {
+		selectorStr = "<all>"
+	}
+	selectorHash, err := hash(selectorStr)
 	if err != nil {
-		return fmt.Errorf("failed to hash pod selector %q: %w", peer.PodSelector.String(), err)
+		return fmt.Errorf("failed to hash pod selector %q: %w", selectorStr, err)
 	}
 
 	ipSet := &nftables.Set{

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -1280,7 +1280,7 @@ func (n *nftState) addIPRule(chainName string, addrs []string, chain *nftables.C
 	if peer.PodSelector != nil {
 		selectorStr = peer.PodSelector.String()
 	} else {
-		selectorStr = "<all>"
+		selectorStr = "<none>"
 	}
 	selectorHash, err := hash(selectorStr)
 	if err != nil {

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -1280,7 +1280,7 @@ func (n *nftState) addIPRule(chainName string, addrs []string, chain *nftables.C
 	if peer.PodSelector != nil {
 		selectorStr = peer.PodSelector.String()
 	} else {
-		selectorStr = "<none>"
+		selectorStr = "<all>"
 	}
 	selectorHash, err := hash(selectorStr)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes two bugs in `applyPolicyPeersRulesSelector` (`pkg/server/netfilterrules.go`) triggered when a `MultiNetworkPolicy` peer has only a `NamespaceSelector` set (nil `PodSelector`).

### Bug 1 — Nil dereference in debug log (line 1158)

`peer.PodSelector.String()` was called unconditionally, panicking when `PodSelector` is nil.

**Fix:** Guard the log statement with a nil check.

### Bug 2 — Wrong selector: labels.Nothing() instead of labels.Everything() (lines 1159–1162)

`metav1.LabelSelectorAsSelector(nil)` returns `labels.Nothing()`, which matches **zero** pods. A namespaceSelector-only peer is supposed to match **all** pods in the matched namespaces, but instead silently allowed zero traffic.

The call site (line 1381) routes to this function when `peer.PodSelector != nil || peer.NamespaceSelector != nil`, so the namespaceSelector-only case definitely reaches the buggy code.

**Fix:** When `PodSelector` is nil, use `labels.Everything()` so the lister returns all pods (namespace filtering is done separately by the existing `nsSelector` check below).

### Test

Added `TestApplyPodRulesNamespaceSelectorOnlyPeer` in `netfilterrules_test.go` — exercises `applyPodRules` with a peer that has only `NamespaceSelector` (nil `PodSelector`), verifying no panic and no error.