### PR TITLE
fix: minimize RBAC wildcards and drop unnecessary DaemonSet privileges

### DIFF
--- a/demo/deploy.yml
+++ b/demo/deploy.yml
@@ -6,9 +6,12 @@ metadata:
 rules:
   - apiGroups: ["k8s.cni.cncf.io"]
     resources:
-      - '*'
+      - multinetworkpolicies
+      - network-attachment-definitions
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -102,12 +105,12 @@ spec:
             cpu: "100m"
             memory: "50Mi"
         securityContext:
-          privileged: true
           capabilities:
             add: ["SYS_ADMIN", "SYS_NET_ADMIN"]
         volumeMounts:
         - name: host
           mountPath: /host
+          readOnly: true
       volumes:
         - name: host
           hostPath:

--- a/demo/deploy.yml
+++ b/demo/deploy.yml
@@ -106,7 +106,7 @@ spec:
             memory: "50Mi"
         securityContext:
           capabilities:
-            add: ["SYS_ADMIN", "SYS_NET_ADMIN"]
+            add: ["SYS_ADMIN", "NET_ADMIN"]
         volumeMounts:
         - name: host
           mountPath: /host

--- a/demo/deploy.yml
+++ b/demo/deploy.yml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: ["k8s.cni.cncf.io"]
     resources:
-      - multinetworkpolicies
+      - multi-networkpolicies
       - network-attachment-definitions
     verbs:
       - get

--- a/deploy.yml
+++ b/deploy.yml
@@ -6,9 +6,12 @@ metadata:
 rules:
   - apiGroups: ["k8s.cni.cncf.io"]
     resources:
-      - '*'
+      - multinetworkpolicies
+      - network-attachment-definitions
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -142,12 +145,12 @@ spec:
             cpu: "100m"
             memory: "150Mi"
         securityContext:
-          privileged: true
           capabilities:
             add: ["SYS_ADMIN", "NET_ADMIN"]
         volumeMounts:
         - name: host
           mountPath: /host
+          readOnly: true
         - name: var-lib-multinetworkpolicy
           mountPath: /var/lib/multi-networkpolicy
         - name: multi-networkpolicy-custom-rules

--- a/deploy.yml
+++ b/deploy.yml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: ["k8s.cni.cncf.io"]
     resources:
-      - multinetworkpolicies
+      - multi-networkpolicies
       - network-attachment-definitions
     verbs:
       - get


### PR DESCRIPTION
## Summary
- Scopes ClusterRole from wildcard `resources: ['*'], verbs: ['*']` to specific resources (`multinetworkpolicies`, `network-attachment-definitions`) with read-only verbs (`get`, `list`, `watch`)
- Removes `privileged: true` from DaemonSet security context, keeping only required capabilities (`SYS_ADMIN`, `NET_ADMIN`)
- Makes host root volume mount read-only
- Addresses code review findings F2 (HIGH) and F3 (HIGH)

## Changes
- `deploy.yml`: ClusterRole scoped, security context minimized, volume mount set to readOnly
- `demo/deploy.yml`: Same changes applied consistently

## Risk Assessment
- RBAC change: Low risk — code only creates informers (read-only watches/lists). Verified no write operations needed.
- Privilege change: Medium risk — `SYS_ADMIN` + `NET_ADMIN` capabilities should be sufficient for nftables operations + netns entry. The daemon doesn't need full privileged mode. Needs e2e validation.
- readOnly mount: Low risk — daemon only reads `/host/proc/<pid>/ns/net` paths.