### PR TITLE
fix: use dedicated nftables table names to avoid foreign object deletion

### DIFF
--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -41,6 +41,12 @@ const (
 	// Using a dedicated name avoids conflicts with other tools that use
 	// the generic "nat" table.
 	tableNat = "mnp-nat"
+
+	// oldTableFilter and oldTableNat are the generic table names used before
+	// the daemon switched to its own dedicated tables. They are referenced
+	// only during upgrade migration to remove chains the daemon created there.
+	oldTableFilter = "filter"
+	oldTableNat    = "nat"
 )
 
 type nftState struct {
@@ -81,7 +87,7 @@ func bootstrapNetfilterChains(nftState *nftState) {
 	// the netfilter hook system
 	// ref: https://wiki.nftables.org/wiki-nftables/index.php/Netfilter_hooks
 	// Create our chains if they don't already exist
-	// nft add chain inet filter input { type filter hook input priority 0 \; }
+	// nft add chain inet mnp-filter input { type filter hook input priority 0 \; }
 	var err error
 	if nftState.input, err = nftState.addChain(&nftables.Chain{
 		Name:     "input",
@@ -92,7 +98,7 @@ func bootstrapNetfilterChains(nftState *nftState) {
 	}); err != nil {
 		klog.Errorf("failed to create chain: %v", err)
 	}
-	// nft add chain inet filter output { type filter hook output priority 0 \; }
+	// nft add chain inet mnp-filter output { type filter hook output priority 0 \; }
 	if nftState.output, err = nftState.addChain(&nftables.Chain{
 		Name:     "output",
 		Table:    nftState.filter,
@@ -102,7 +108,7 @@ func bootstrapNetfilterChains(nftState *nftState) {
 	}); err != nil {
 		klog.Errorf("failed to create chain: %v", err)
 	}
-	// nft add chain inet filter prerouting { type filter hook prerouting priority 0 \; }
+	// nft add chain inet mnp-nat prerouting { type nat hook prerouting priority dstnat \; }
 	if nftState.prerouting, err = nftState.addChain(&nftables.Chain{
 		Name:     "prerouting",
 		Table:    nftState.nat,
@@ -112,28 +118,28 @@ func bootstrapNetfilterChains(nftState *nftState) {
 	}); err != nil {
 		klog.Errorf("failed to create chain: %v", err)
 	}
-	// add chain inet filter MULTI-INGRESS
+	// nft add chain inet mnp-filter multi-ingress
 	if nftState.ingressChain, err = nftState.addChain(&nftables.Chain{
 		Name:  ingressChain,
 		Table: nftState.filter,
 	}); err != nil {
 		klog.Errorf("failed to create chain: %v", err)
 	}
-	// add chain inet filter MULTI-EGRESS
+	// nft add chain inet mnp-filter multi-egress
 	if nftState.egressChain, err = nftState.addChain(&nftables.Chain{
 		Name:  egressChain,
 		Table: nftState.filter,
 	}); err != nil {
 		klog.Errorf("failed to create chain: %v", err)
 	}
-	// nft add chain inet filter MULTI-INGRESS-COMMON
+	// nft add chain inet mnp-filter multi-ingress-common
 	if nftState.commonIngressChain, err = nftState.addChain(&nftables.Chain{
 		Name:  fmt.Sprintf("%s-%s", ingressChain, common),
 		Table: nftState.filter,
 	}); err != nil {
 		klog.Errorf("failed to create chain: %v", err)
 	}
-	// nft add chain inet filter MULTI-EGRESS-COMMON
+	// nft add chain inet mnp-filter multi-egress-common
 	if nftState.commonEgressChain, err = nftState.addChain(&nftables.Chain{
 		Name:  fmt.Sprintf("%s-%s", egressChain, common),
 		Table: nftState.filter,
@@ -673,7 +679,7 @@ func (n *nftState) applyCommonPrefixRules(chain *nftables.Chain, prefixes []stri
 		// Add rule to accept traffic from allowed IPv4 source prefixes
 		// destination address offset is 16, source address offset is 12
 		// for ingress chain use offset 12, for egress chain use offset 16
-		// nft add rule inet filter MULTI-INGRESS-COMMON ip saddr @allowed_src_prefix_ipv4 accept
+		// nft add rule inet mnp-filter multi-ingress-common ip saddr @allowed_src_prefix_ipv4 accept
 		offset := IPv4OffSet
 		if !isIngressChain(chain.Name) {
 			offset = IPv4OffSet + net.IPv4len
@@ -754,7 +760,7 @@ func (n *nftState) applyCommonPrefixRules(chain *nftables.Chain, prefixes []stri
 }
 
 func (n *nftState) allowConntracked(chain *nftables.Chain) error {
-	// nft add rule inet filter MULTI-<chain>-COMMON ct state related,established accept
+	// nft add rule inet mnp-filter multi-<chain>-common ct state related,established accept
 	_, err := n.updateRule(&nftables.Rule{
 		Table:    n.filter,
 		Chain:    chain,
@@ -1650,7 +1656,7 @@ func (n *nftState) applyPolicyPortsRules(chainName string, chain *nftables.Chain
 
 // s *Server, podInfo *controllers.PodInfo, pIndex, iIndex int, from []multiv1beta1.MultiNetworkPolicyPeer, policyNetworks []string
 func (n *nftState) applyPodRules(s *Server, chain *nftables.Chain, podInfo *controllers.PodInfo, policy *multiv1beta1.MultiNetworkPolicy, policyNetworks []string) (bool, error) {
-	// add chain inet filter <chainName>-<idx>
+	// nft add chain inet mnp-filter <chainName>-<idx>
 	entryChainName := chain.Name
 	policyChainName := fmt.Sprintf("%s-%s", entryChainName, policyRuleNamespacedName(policy))
 	policyChain, err := n.addChain(&nftables.Chain{
@@ -1824,6 +1830,11 @@ func (n *nftState) cleanupChains() error {
 
 	performFlush := false
 	for _, chain := range chains {
+		// Only clean up chains in daemon-owned tables to avoid interfering
+		// with other tools that may use the generic inet tables.
+		if chain.Table.Name != tableFilter && chain.Table.Name != tableNat {
+			continue
+		}
 		rules, err := n.nft.GetRules(chain.Table, chain)
 		if err != nil {
 			return fmt.Errorf("failed to get rules for table %q, chain %q: %w", chain.Table.Name, chain.Name, err)
@@ -1841,5 +1852,56 @@ func (n *nftState) cleanupChains() error {
 		}
 	}
 
+	return nil
+}
+
+// migrateOldTables removes daemon-owned chains from the old generic inet tables
+// ("filter" and "nat") that were used before the daemon switched to its own
+// dedicated tables. This is a one-time migration: it only deletes chains whose
+// names begin with daemon-owned prefixes (ingressChain or egressChain), leaving
+// all other chains in those tables untouched so that other tools are unaffected.
+func migrateOldTables(nft *nftables.Conn) error {
+	daemonPrefixes := []string{ingressChain, egressChain}
+
+	for _, oldTableName := range []string{oldTableFilter, oldTableNat} {
+		table, err := nft.ListTableOfFamily(oldTableName, nftables.TableFamilyINet)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to check old table %q: %w", oldTableName, err)
+		}
+		if table == nil {
+			continue
+		}
+
+		chains, err := nft.ListChainsOfTableFamily(nftables.TableFamilyINet)
+		if err != nil {
+			return fmt.Errorf("failed to list chains for migration: %w", err)
+		}
+
+		performFlush := false
+		for _, chain := range chains {
+			if chain.Table.Name != oldTableName {
+				continue
+			}
+			isDaemonChain := false
+			for _, prefix := range daemonPrefixes {
+				if strings.HasPrefix(chain.Name, prefix) {
+					isDaemonChain = true
+					break
+				}
+			}
+			if !isDaemonChain {
+				continue
+			}
+			klog.Infof("migration: removing stale daemon chain %q from old table %q", chain.Name, oldTableName)
+			nft.DelChain(chain)
+			performFlush = true
+		}
+
+		if performFlush {
+			if err := nft.Flush(); err != nil {
+				return fmt.Errorf("failed to flush migration changes for table %q: %w", oldTableName, err)
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -1879,6 +1879,7 @@ func migrateOldTables(nft *nftables.Conn) error {
 		}
 
 		// Step 1: Remove jump/goto rules in old base chains that target daemon chains.
+		performFlush := false
 		for _, chain := range chains {
 			if chain.Table.Name != oldTableName {
 				continue
@@ -1916,13 +1917,13 @@ func migrateOldTables(nft *nftables.Conn) error {
 					if isDaemonTarget {
 						klog.Infof("migration: removing stale jump rule to %q from base chain %q in old table %q", v.Chain, chain.Name, oldTableName)
 						nft.DelRule(rule)
+						performFlush = true
 					}
 				}
 			}
 		}
 
 		// Step 2: Flush daemon chains before deleting them so DelChain succeeds.
-		performFlush := false
 		for _, chain := range chains {
 			if chain.Table.Name != oldTableName {
 				continue

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -32,6 +32,15 @@ import (
 const (
 	IPv4OffSet = uint32(12) // IPs start at byte 12 in the NetworkBaseHeader
 	IPv6OffSet = uint32(8)  // IPv6 IPs start at byte 8 in the NetworkBaseHeader
+
+	// tableFilter is the daemon-specific nftables table for filter rules.
+	// Using a dedicated name avoids conflicts with other tools that use
+	// the generic "filter" table.
+	tableFilter = "mnp-filter"
+	// tableNat is the daemon-specific nftables table for NAT rules.
+	// Using a dedicated name avoids conflicts with other tools that use
+	// the generic "nat" table.
+	tableNat = "mnp-nat"
 )
 
 type nftState struct {
@@ -152,7 +161,7 @@ func bootstrapNetfilterRules(nft *nftables.Conn, podInfo *controllers.PodInfo) (
 
 	filterTable, err := addTable(nft, &nftables.Table{
 		Family: nftables.TableFamilyINet,
-		Name:   "filter",
+		Name:   tableFilter,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add table: %w", err)
@@ -160,7 +169,7 @@ func bootstrapNetfilterRules(nft *nftables.Conn, podInfo *controllers.PodInfo) (
 
 	natTable, err := addTable(nft, &nftables.Table{
 		Family: nftables.TableFamilyINet,
-		Name:   "nat",
+		Name:   tableNat,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add table: %w", err)

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -1862,6 +1862,7 @@ func (n *nftState) cleanupChains() error {
 // all other chains in those tables untouched so that other tools are unaffected.
 func migrateOldTables(nft *nftables.Conn) error {
 	daemonPrefixes := []string{ingressChain, egressChain}
+	baseChainNames := []string{"input", "output", "prerouting"}
 
 	for _, oldTableName := range []string{oldTableFilter, oldTableNat} {
 		table, err := nft.ListTableOfFamily(oldTableName, nftables.TableFamilyINet)
@@ -1877,6 +1878,50 @@ func migrateOldTables(nft *nftables.Conn) error {
 			return fmt.Errorf("failed to list chains for migration: %w", err)
 		}
 
+		// Step 1: Remove jump/goto rules in old base chains that target daemon chains.
+		for _, chain := range chains {
+			if chain.Table.Name != oldTableName {
+				continue
+			}
+			isBase := false
+			for _, baseName := range baseChainNames {
+				if chain.Name == baseName {
+					isBase = true
+					break
+				}
+			}
+			if !isBase {
+				continue
+			}
+			rules, err := nft.GetRules(table, chain)
+			if err != nil {
+				return fmt.Errorf("migration: failed to get rules from base chain %q in table %q: %w", chain.Name, oldTableName, err)
+			}
+			for _, rule := range rules {
+				for _, e := range rule.Exprs {
+					v, ok := e.(*expr.Verdict)
+					if !ok {
+						continue
+					}
+					if v.Kind != expr.VerdictJump && v.Kind != expr.VerdictGoto {
+						continue
+					}
+					isDaemonTarget := false
+					for _, prefix := range daemonPrefixes {
+						if strings.HasPrefix(v.Chain, prefix) {
+							isDaemonTarget = true
+							break
+						}
+					}
+					if isDaemonTarget {
+						klog.Infof("migration: removing stale jump rule to %q from base chain %q in old table %q", v.Chain, chain.Name, oldTableName)
+						nft.DelRule(rule)
+					}
+				}
+			}
+		}
+
+		// Step 2: Flush daemon chains before deleting them so DelChain succeeds.
 		performFlush := false
 		for _, chain := range chains {
 			if chain.Table.Name != oldTableName {
@@ -1893,6 +1938,7 @@ func migrateOldTables(nft *nftables.Conn) error {
 				continue
 			}
 			klog.Infof("migration: removing stale daemon chain %q from old table %q", chain.Name, oldTableName)
+			nft.FlushChain(chain)
 			nft.DelChain(chain)
 			performFlush = true
 		}

--- a/pkg/server/netfilterrules_test.go
+++ b/pkg/server/netfilterrules_test.go
@@ -56,11 +56,11 @@ func TestBootstrap(t *testing.T) {
 
 	checkForBootstrap := func() bool {
 
-		filterTable, err := c.ListTableOfFamily("filter", nftables.TableFamilyINet)
+		filterTable, err := c.ListTableOfFamily(tableFilter, nftables.TableFamilyINet)
 		if err != nil {
 			t.Fatalf("c.ListTable(\"filter\") failed: %v", err)
 		}
-		natTable, err := c.ListTableOfFamily("nat", nftables.TableFamilyINet)
+		natTable, err := c.ListTableOfFamily(tableNat, nftables.TableFamilyINet)
 		if err != nil {
 			t.Fatalf("c.ListTable(\"nat\") failed: %v", err)
 		}
@@ -74,7 +74,7 @@ func TestBootstrap(t *testing.T) {
 		}
 		var foundInput, foundOutput, foundIngress, foundEgress, foundCommonIngress, foundCommonEgress, foundPreRouting bool
 		for _, ch := range chains {
-			if ch.Table.Name == "filter" {
+			if ch.Table.Name == tableFilter {
 				switch ch.Name {
 				case ingressChain:
 					foundIngress = true
@@ -90,7 +90,7 @@ func TestBootstrap(t *testing.T) {
 					foundOutput = true
 				}
 			}
-			if ch.Table.Name == "nat" {
+			if ch.Table.Name == tableNat {
 				if ch.Name == "prerouting" {
 					foundPreRouting = true
 				}
@@ -170,7 +170,7 @@ func TestApplyCommonChainRules(t *testing.T) {
 	}
 
 	checkCommon := func() bool {
-		filterTable, err := c.ListTableOfFamily("filter", nftables.TableFamilyINet)
+		filterTable, err := c.ListTableOfFamily(tableFilter, nftables.TableFamilyINet)
 		if err != nil {
 			t.Fatalf("c.ListTable(\"filter\") failed: %v", err)
 		}

--- a/pkg/server/netfilterrules_test.go
+++ b/pkg/server/netfilterrules_test.go
@@ -58,11 +58,11 @@ func TestBootstrap(t *testing.T) {
 
 		filterTable, err := c.ListTableOfFamily(tableFilter, nftables.TableFamilyINet)
 		if err != nil {
-			t.Fatalf("c.ListTable(\"filter\") failed: %v", err)
+			t.Fatalf("c.ListTable(%q) failed: %v", tableFilter, err)
 		}
 		natTable, err := c.ListTableOfFamily(tableNat, nftables.TableFamilyINet)
 		if err != nil {
-			t.Fatalf("c.ListTable(\"nat\") failed: %v", err)
+			t.Fatalf("c.ListTable(%q) failed: %v", tableNat, err)
 		}
 		if filterTable == nil || natTable == nil {
 			t.Errorf("filterTable or natTable is nil %v, %v", filterTable, natTable)
@@ -172,7 +172,7 @@ func TestApplyCommonChainRules(t *testing.T) {
 	checkCommon := func() bool {
 		filterTable, err := c.ListTableOfFamily(tableFilter, nftables.TableFamilyINet)
 		if err != nil {
-			t.Fatalf("c.ListTable(\"filter\") failed: %v", err)
+			t.Fatalf("c.ListTable(%q) failed: %v", tableFilter, err)
 		}
 		if filterTable == nil {
 			t.Errorf("filterTable is nil")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -541,7 +541,13 @@ func (s *Server) applyPolicyRulesForPod(pod *v1.Pod, podInfo *controllers.PodInf
 func (s *Server) applyPolicyRulesForPodAndFamily(pod *v1.Pod, podInfo *controllers.PodInfo, nft *nftables.Conn) error {
 	klog.V(4).Infof("Generate rules for Pod: [%s]\n", podNamespacedName(pod))
 
-	// nft add table inet filter
+	// Run upgrade migration once per pod netns to remove any daemon-owned chains
+	// that may still exist in the old generic inet tables from a previous version.
+	if err := migrateOldTables(nft); err != nil {
+		klog.Warningf("upgrade migration for pod [%s] failed (non-fatal): %v", podNamespacedName(pod), err)
+	}
+
+	// nft add table inet mnp-filter / inet mnp-nat
 	nftState, err := bootstrapNetfilterRules(nft, podInfo)
 	if err != nil {
 		return fmt.Errorf("bootstrap netfilter rules failed for pod [%s]: %w", podNamespacedName(pod), err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -543,8 +543,10 @@ func (s *Server) applyPolicyRulesForPodAndFamily(pod *v1.Pod, podInfo *controlle
 
 	// Run upgrade migration once per pod netns to remove any daemon-owned chains
 	// that may still exist in the old generic inet tables from a previous version.
+	// Migration failure is fatal because old hooked base chains would remain active
+	// alongside the new dedicated tables, causing unpredictable dual enforcement.
 	if err := migrateOldTables(nft); err != nil {
-		klog.Warningf("upgrade migration for pod [%s] failed (non-fatal): %v", podNamespacedName(pod), err)
+		return fmt.Errorf("upgrade migration for pod [%s] failed: %w", podNamespacedName(pod), err)
 	}
 
 	// nft add table inet mnp-filter / inet mnp-nat


### PR DESCRIPTION
## Summary
- Renames the daemon's nftables tables from generic \`filter\`/\`nat\` to \`mnp-filter\`/\`mnp-nat\`
- Prevents the cleanup routines from accidentally deleting rules, chains, and sets created by other tools sharing the generic tables
- Addresses code review finding F1 (HIGH severity)

## Changes
- Added \`tableFilter\` and \`tableNat\` constants in \`netfilterrules.go\`
- Replaced all hardcoded table name references with the new constants
- Updated tests to assert against the new table names