### PR TITLE
docs: fix obsolete CLI flag names and descriptions

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -132,8 +132,8 @@ spec:
         # change this if runtime is different that crio default
         - "--container-runtime-endpoint=/run/crio/crio.sock"
         # uncomment this if you need to accept link-local address traffic
-        #- "--allow-ipv6-src-prefix=fe80::/10"
-        #- "--allow-ipv6-dst-prefix=fe80::/10"
+        #- "--allow-src-prefix=fe80::/10"
+        #- "--allow-dst-prefix=fe80::/10"
         # uncomment if you want to accept ICMP/ICMPv6 traffic
         #- "--accept-icmp"
         #- "--accept-icmpv6"

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -11,12 +11,11 @@ $ ./multi-networkpolicy-nftables --help
 
 ### Advanced Options
 
-#### Add exceptional IPv6 prefix address to accept
+#### Add exceptional IP prefix address to accept
 
-Some IPv6 networks may require accepting traffic from/to specific address prefixes for the network, such as multicast address (all routers multicast address, link-local address and so on). You can configure `--allow-ipv6-src-prefix` and `--allow-ipv6-dst-prefix` to specify which prefix should be accepted (even though network policy does not have it). Both options accept comma separated IPv6 prefix list.
+Some networks may require accepting traffic from/to specific address prefixes for the network, such as multicast address (all routers multicast address, link-local address and so on). You can configure `--allow-src-prefix` and `--allow-dst-prefix` to specify which prefix should be accepted (even though network policy does not have it). Both options accept a comma-separated CIDR list.
 
 ```
---allow-ipv6-src-prefix=fe80::/10
---allow-ipv6-dst-prefix=fe80::/10,ff00::/8
+--allow-src-prefix=fe80::/10
+--allow-dst-prefix=fe80::/10,ff00::/8
 ```
-

--- a/e2e/multi-network-policy-nftables-e2e.yml
+++ b/e2e/multi-network-policy-nftables-e2e.yml
@@ -130,8 +130,8 @@ spec:
         # (e2e test only) enshorten sync period to fast sync
         - "--sync-period=1"
         # uncomment this if you need to accept link-local address traffic
-        #- "--allow-ipv6-src-prefix=fe80::/10"
-        #- "--allow-ipv6-dst-prefix=fe80::/10"
+        #- "--allow-src-prefix=fe80::/10"
+        #- "--allow-dst-prefix=fe80::/10"
         # uncomment if you want to accept ICMP/ICMPv6 traffic
         # - "--accept-icmp"
         # - "--accept-icmpv6"

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -68,8 +68,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.syncPeriod, "sync-period", defaultSyncPeriod, "sync period for multi-networkpolicy syncRunner")
 	fs.BoolVar(&o.acceptICMP, "accept-icmp", false, "accept all ICMP traffic")
 	fs.BoolVar(&o.acceptICMPv6, "accept-icmpv6", false, "accept all ICMPv6 traffic")
-	fs.StringVar(&o.allowSrcPrefixText, "allow-src-prefix", "", "Accept source IPv6 prefix list, comma separated (e.g. \"fe80::/10\")")
-	fs.StringVar(&o.allowDstPrefixText, "allow-dst-prefix", "", "Accept destination IPv6 prefix list, comma separated (e.g. \"fe80:/10,ff00::/8\")")
+	fs.StringVar(&o.allowSrcPrefixText, "allow-src-prefix", "", "Accept source IP prefix list, comma separated CIDRs (e.g. \"fe80::/10\")")
+	fs.StringVar(&o.allowDstPrefixText, "allow-dst-prefix", "", "Accept destination IP prefix list, comma separated CIDRs (e.g. \"fe80::/10,ff00::/8\")")
 	fs.AddGoFlagSet(flag.CommandLine)
 }
 
@@ -91,12 +91,10 @@ func parseIPPrefixText(prefixText string, prefixList *[]string) error {
 // Validate checks several options and fill processed value
 func (o *Options) Validate() error {
 
-	// Validate IPv6 source prefix list
 	if err := parseIPPrefixText(o.allowSrcPrefixText, &o.allowSrcPrefix); err != nil {
 		return err
 	}
 
-	// Validate IPv6 destination prefix list
 	if err := parseIPPrefixText(o.allowDstPrefixText, &o.allowDstPrefix); err != nil {
 		return err
 	}
@@ -117,7 +115,6 @@ func (o *Options) Run() error {
 	klog.Infof("hostname: %v", hostname)
 	klog.Infof("container-runtime: %v", o.containerRuntime)
 
-	// validate option and update it (check v6prefix list)
 	err = o.Validate()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary\n- Update docs and deploy examples to use the current `--allow-src-prefix` / `--allow-dst-prefix` flags\n- Clarify the flags accept any CIDR, not only IPv6 prefixes\n- Keep code behavior unchanged\n\n## Verification\n- GOOS=linux go build ./...\n- make fmt