### PR TITLE
fix: correct len >= 0 always-true check in namespace and net-attach-def trackers

### DIFF
--- a/pkg/controllers/namespace.go
+++ b/pkg/controllers/namespace.go
@@ -214,7 +214,7 @@ func (nct *NamespaceChangeTracker) Update(previous, current *v1.Namespace) bool 
 	if reflect.DeepEqual(change.previous, change.current) {
 		delete(nct.items, ns.Name)
 	}
-	return len(nct.items) >= 0
+	return len(nct.items) > 0
 }
 
 // NamespaceMap ...

--- a/pkg/controllers/namespace_test.go
+++ b/pkg/controllers/namespace_test.go
@@ -175,8 +175,7 @@ var _ = Describe("namespace controller", func() {
 		nsMap := make(NamespaceMap)
 		nsMap.Update(nsChanges)
 
-		nsChanges2 := NewNamespaceChangeTracker()
-		Expect(nsChanges2.Update(
+		Expect(nsChanges.Update(
 			NewNamespace("test1", labels),
 			NewNamespace("test1", labels),
 		)).To(BeFalse())

--- a/pkg/controllers/namespace_test.go
+++ b/pkg/controllers/namespace_test.go
@@ -167,4 +167,18 @@ var _ = Describe("namespace controller", func() {
 		Expect(ok).To(BeTrue())
 		Expect(labelTest).To(Equal("labelValue2"))
 	})
+
+	It("Update ns with same data returns false (no pending changes)", func() {
+		nsChanges := NewNamespaceChangeTracker()
+		labels := map[string]string{"labelName1": "labelValue1"}
+		Expect(nsChanges.Update(nil, NewNamespace("test1", labels))).To(BeTrue())
+		nsMap := make(NamespaceMap)
+		nsMap.Update(nsChanges)
+
+		nsChanges2 := NewNamespaceChangeTracker()
+		Expect(nsChanges2.Update(
+			NewNamespace("test1", labels),
+			NewNamespace("test1", labels),
+		)).To(BeFalse())
+	})
 })

--- a/pkg/controllers/net-attach-def.go
+++ b/pkg/controllers/net-attach-def.go
@@ -299,7 +299,7 @@ func (ndt *NetDefChangeTracker) Update(previous, current *netdefv1.NetworkAttach
 		delete(ndt.items, namespacedName)
 	}
 
-	return len(ndt.items) >= 0
+	return len(ndt.items) > 0
 }
 
 // NewNetDefChangeTracker ...

--- a/pkg/controllers/net-attach-def_test.go
+++ b/pkg/controllers/net-attach-def_test.go
@@ -191,4 +191,13 @@ var _ = Describe("net-attach-def controller", func() {
 		Expect(ndTest1.Name()).To(Equal("test1"))
 		Expect(ndTest1.PluginType).To(Equal("testType2"))
 	})
+
+	It("Update netdef with same data returns false (no pending changes)", func() {
+		cniConfig := NewCNIConfig("cniConfig1", "testType1")
+		ndChanges := NewNetDefChangeTracker()
+		Expect(ndChanges.Update(
+			NewNetDef("testns1", "test1", cniConfig),
+			NewNetDef("testns1", "test1", cniConfig),
+		)).To(BeFalse())
+	})
 })


### PR DESCRIPTION
## Summary

- Fixes `len(items) >= 0` always-true bug in `NamespaceChangeTracker` and `NetDefChangeTracker`
- These two files were missed in PR #50 which fixed the same bug in `PodChangeTracker` and `PolicyChangeTracker`
- `>= 0` always evaluates to `true` for unsigned `len()`, causing trackers to report changes even when none occurred

## Changes

- `pkg/controllers/namespace.go`: `return len(nct.items) >= 0` → `return len(nct.items) > 0`
- `pkg/controllers/net-attach-def.go`: `return len(ndt.items) >= 0` → `return len(ndt.items) > 0`
- Added unit tests verifying trackers return `false` when no items changed

## Testing

- `make test` ✅ (CI)
- `make lint` ✅ (CI)