### PR TITLE
fix: include pod labels in PodInfo for change tracking

### DIFF
--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -210,6 +210,7 @@ type PodInfo struct {
 	NetworkStatus []netdefv1.NetworkStatus
 	NodeName      string
 	Interfaces    []InterfaceInfo
+	Labels        map[string]string
 }
 
 // CheckPolicyNetwork checks whether given pod is target or not,
@@ -423,6 +424,7 @@ func (pct *PodChangeTracker) newPodInfo(pod *v1.Pod) *PodInfo {
 		NetNSPath:     netnsPath,
 		NodeName:      pod.Spec.NodeName,
 		Interfaces:    netifs,
+		Labels:        pod.Labels,
 	}
 	return info
 }

--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -424,7 +425,7 @@ func (pct *PodChangeTracker) newPodInfo(pod *v1.Pod) *PodInfo {
 		NetNSPath:     netnsPath,
 		NodeName:      pod.Spec.NodeName,
 		Interfaces:    netifs,
-		Labels:        pod.Labels,
+		Labels:        maps.Clone(pod.Labels),
 	}
 	return info
 }

--- a/pkg/controllers/pod_test.go
+++ b/pkg/controllers/pod_test.go
@@ -326,6 +326,37 @@ var _ = Describe("pod controller", func() {
 		Expect(pod1.Labels["a"]).To(Equal("c"))
 	})
 
+	It("Pod with nil labels does not panic (maps.Clone nil-safe)", func() {
+		ndChanges := NewNetDefChangeTracker()
+		podChanges := NewFakePodChangeTracker("nodeName", "hostPrefix", ndChanges)
+		pod := NewFakePodWithLabels("testns1", "testpod1", nil)
+
+		Expect(podChanges.Update(nil, pod)).To(BeTrue())
+		podMap := make(PodMap)
+		podMap.Update(podChanges)
+
+		info, ok := podMap[types.NamespacedName{Namespace: "testns1", Name: "testpod1"}]
+		Expect(ok).To(BeTrue())
+		Expect(info.Labels).To(BeNil())
+	})
+
+	It("Pod with empty labels does not panic and isolation is preserved", func() {
+		ndChanges := NewNetDefChangeTracker()
+		podChanges := NewFakePodChangeTracker("nodeName", "hostPrefix", ndChanges)
+		originalLabels := map[string]string{}
+		pod := NewFakePodWithLabels("testns1", "testpod1", originalLabels)
+
+		Expect(podChanges.Update(nil, pod)).To(BeTrue())
+		podMap := make(PodMap)
+		podMap.Update(podChanges)
+
+		originalLabels["injected"] = "value"
+
+		info, ok := podMap[types.NamespacedName{Namespace: "testns1", Name: "testpod1"}]
+		Expect(ok).To(BeTrue())
+		Expect(info.Labels).NotTo(HaveKey("injected"))
+	})
+
 })
 
 var _ = Describe("runtime kind", func() {

--- a/pkg/controllers/pod_test.go
+++ b/pkg/controllers/pod_test.go
@@ -111,6 +111,25 @@ func NewFakeNetworkStatus(netns, netname string) string {
 	return fmt.Sprintf(baseStr, netns, netname)
 }
 
+func NewFakePodWithLabels(namespace, name string, labels map[string]string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       "testUID",
+			Labels:    labels,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "ctr1", Image: "image"},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+}
+
 func NewFakePod(namespace, name string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -285,6 +304,26 @@ var _ = Describe("pod controller", func() {
 		podChanges.Update(nil, NewFakePod("testns1", "testpod1"))
 		result := podChanges.Update(NewFakePod("testns1", "testpod1"), nil)
 		Expect(result).To(BeFalse())
+	})
+
+	It("Label change triggers tracker diff", func() {
+		ndChanges := NewNetDefChangeTracker()
+		podChanges := NewFakePodChangeTracker("nodeName", "hostPrefix", ndChanges)
+
+		oldPod := NewFakePodWithLabels("testns1", "testpod1", map[string]string{"a": "b"})
+		newPod := NewFakePodWithLabels("testns1", "testpod1", map[string]string{"a": "c"})
+
+		Expect(podChanges.Update(nil, oldPod)).To(BeTrue())
+		podMap := make(PodMap)
+		podMap.Update(podChanges)
+
+		Expect(podChanges.Update(oldPod, newPod)).To(BeTrue())
+		Expect(len(podChanges.items)).To(Equal(1))
+
+		podMap.Update(podChanges)
+		pod1, ok := podMap[types.NamespacedName{Namespace: "testns1", Name: "testpod1"}]
+		Expect(ok).To(BeTrue())
+		Expect(pod1.Labels["a"]).To(Equal("c"))
 	})
 
 })


### PR DESCRIPTION
## Summary

Pod label changes were not triggering policy recalculation because `PodInfo` did not track labels. When a pod's labels changed, the controller compared old and new `PodInfo` structs and found them equal, silently skipping the update.

## Changes

- Added a `Labels` map to `PodInfo` so label state is captured in the snapshot used for change tracking
- Clone the pod label map when building `PodInfo` so later mutations do not affect stored state
- When pod labels change, the copied map changes, causing the controller to correctly detect the update and recalculate affected policies

## Files Changed

- `pkg/controllers/pod.go` — Clone pod labels when building `PodInfo`
- `pkg/controllers/pod_test.go` — Added test verifying label change detection

## Testing

- New Ginkgo spec: `Label change triggers tracker diff` validates that label changes produce different snapshots
- Existing tests continue to pass