### PR TITLE
fix: remove redundant in-loop podMap.Update from syncMultiPolicy

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -470,7 +470,6 @@ func (s *Server) syncMultiPolicy() error {
 		return fmt.Errorf("failed to list pods for sync: %w", err)
 	}
 	for _, p := range pods {
-		s.podMap.Update(s.podChanges)
 		if !controllers.IsMultiNetworkpolicyTarget(p) {
 			klog.V(8).Infof("SKIP SYNC %s/%s", p.Namespace, p.Name)
 			continue


### PR DESCRIPTION
## Summary

`syncMultiPolicy` calls `s.podMap.Update(s.podChanges)` once before the pod loop to snapshot pending changes, then calls the same `Update` **again** inside the per-pod iteration. The in-loop call drains the change tracker mid-iteration, allowing informer callbacks that arrive during the sync to mutate `podChanges` and be applied inconsistently — earlier pods in the loop see a different snapshot than later ones.

## Root Cause

```go
s.podMap.Update(s.podChanges)  // correct: snapshot at start
s.policyMap.Update(s.policyChanges)
for _, p := range pods {
    s.podMap.Update(s.podChanges)  // BUG: double-drain
    ...
}
```

`namespaceMap` and `policyMap` are not re-updated inside the loop. The `podMap` call was inconsistent with the rest and introduced a race where concurrent `OnPodUpdate`/`OnPodDelete` events could be partially applied inside a single sync cycle.

## Fix

Remove the in-loop `s.podMap.Update(s.podChanges)` call. The snapshot is now taken once at function start, consistent with all other map updates.

## Impact

- All pods in a sync cycle are processed against the same consistent snapshot.
- Events that arrive during a sync are queued in `podChanges` and applied on the next sync cycle.
- No behaviour change in the common case (no concurrent events mid-sync).