### PR TITLE
fix: propagate applyPodRules and applyDropRemaining errors as fatal

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -615,7 +615,7 @@ func (s *Server) applyPolicyRulesForPodAndFamily(pod *v1.Pod, podInfo *controlle
 		for _, policy := range ingressPolicies {
 			newRules, err := nftState.applyPodRules(s, nftState.ingressChain, podInfo, policy.policy, policy.policyNetworks)
 			if err != nil {
-				klog.Errorf("failed to apply pod ingress rules: %v", err)
+				return fmt.Errorf("failed to apply pod ingress rules for policy %q: %w", policyNamespacedName(policy.policy), err)
 			}
 			if newRules {
 				forceUpdate = true
@@ -625,7 +625,7 @@ func (s *Server) applyPolicyRulesForPodAndFamily(pod *v1.Pod, podInfo *controlle
 			}
 		}
 		if err := nftState.applyDropRemaining(nftState.ingressChain, forceUpdate); err != nil {
-			klog.Errorf("failed to apply drop-remaining ingress rules: %v", err)
+			return fmt.Errorf("failed to apply drop-remaining ingress rules: %w", err)
 		}
 	}
 
@@ -634,7 +634,7 @@ func (s *Server) applyPolicyRulesForPodAndFamily(pod *v1.Pod, podInfo *controlle
 		for _, policy := range egressPolicies {
 			newRules, err := nftState.applyPodRules(s, nftState.egressChain, podInfo, policy.policy, policy.policyNetworks)
 			if err != nil {
-				klog.Errorf("failed to apply pod egress rules: %v", err)
+				return fmt.Errorf("failed to apply pod egress rules for policy %q: %w", policyNamespacedName(policy.policy), err)
 			}
 			if newRules {
 				forceUpdate = true
@@ -644,7 +644,7 @@ func (s *Server) applyPolicyRulesForPodAndFamily(pod *v1.Pod, podInfo *controlle
 			}
 		}
 		if err := nftState.applyDropRemaining(nftState.egressChain, forceUpdate); err != nil {
-			klog.Errorf("failed to apply drop-remaining egress rules: %v", err)
+			return fmt.Errorf("failed to apply drop-remaining egress rules: %w", err)
 		}
 	}
 	if err := nftState.nft.Flush(); err != nil {


### PR DESCRIPTION
## Summary

When `applyPodRules` or `applyDropRemaining` failed, the error was logged and execution continued. The subsequent `nft.Flush()` then committed whatever partial state had been accumulated — meaning allow rules for some policies may be absent while the drop-remaining rule is present, silently dropping all traffic for the pod.

## Root Cause

```go
newRules, err := nftState.applyPodRules(...)
if err != nil {
    klog.Errorf("failed to apply pod ingress rules: %v", err)
    // BUG: continues; nft.Flush() is called with incomplete state
}
// ...
if err := nftState.applyDropRemaining(nftState.ingressChain, forceUpdate); err != nil {
    klog.Errorf("failed to apply drop-remaining ingress rules: %v", err)
    // BUG: continues; partial ruleset is flushed
}
```

The asymmetry is dangerous: `applyGeneralMarkCheck` already returns its error correctly, but `applyPodRules` and `applyDropRemaining` did not.

## Fix

Return errors from `applyPodRules` and `applyDropRemaining` immediately, propagating them to `applyPolicyForPodInNetNs` which then returns without calling `nft.Flush()`. The per-pod failure is already logged by `syncMultiPolicy`.

## Impact

- Failed pod syncs no longer commit partial nftables state.
- Traffic is not silently dropped when allow-rule installation fails.
- `syncMultiPolicy` already logs per-pod errors; no logging change needed at call site.
- On the next sync cycle the full ruleset will be re-attempted.