### PR TITLE
fix: enforce nftables identifier length limit in policy chain names

### DIFF
--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -119,6 +119,19 @@ func truncateNftName(name string, maxLen int) string {
 	return prefix + suffix
 }
 
+func nftNameWithSuffix(base, separator, suffix string) string {
+	sanitizedSeparator := strings.Map(sanitizeNftChar, separator)
+	sanitizedSuffix := strings.Map(sanitizeNftChar, suffix)
+	suffixLen := len(sanitizedSeparator) + len(sanitizedSuffix)
+	if suffixLen == 0 {
+		return truncateNftName(base, nftNameMaxLen)
+	}
+	if suffixLen >= nftNameMaxLen {
+		return truncateNftName(base+sanitizedSeparator+sanitizedSuffix, nftNameMaxLen)
+	}
+	return truncateNftName(base, nftNameMaxLen-suffixLen) + sanitizedSeparator + sanitizedSuffix
+}
+
 func bootstrapNetfilterChains(nftState *nftState) {
 	// the netfilter hook system
 	// ref: https://wiki.nftables.org/wiki-nftables/index.php/Netfilter_hooks
@@ -1422,7 +1435,7 @@ func (n *nftState) addIPRules(chainName string, addrs []string, chain *nftables.
 
 func (n *nftState) applyPolicyPeersRules(s *Server, chainName string, chain *nftables.Chain, policyName string, peers []multiv1beta1.MultiNetworkPolicyPeer,
 	podInfo *controllers.PodInfo, policyNetworks []string, peerIndex int) error {
-	peersName := fmt.Sprintf("%s-%s-%d", chainName, peersChainSuffix, peerIndex)
+	peersName := nftNameWithSuffix(chainName, "-", fmt.Sprintf("%s-%d", peersChainSuffix, peerIndex))
 
 	peersChain, err := n.addChain(&nftables.Chain{
 		Name:  peersName,
@@ -1520,7 +1533,7 @@ func (n *nftState) findRule(rule *nftables.Rule) (*nftables.Rule, error) {
 }
 
 func (n *nftState) getInetSet(chain *nftables.Chain, portsName, suffix string) *nftables.Set {
-	setName := fmt.Sprintf("%s_%s", getSetName(portsName), suffix)
+	setName := nftNameWithSuffix(getSetName(portsName), "_", suffix)
 	return &nftables.Set{
 		Table:    chain.Table,
 		Name:     setName,
@@ -1577,7 +1590,7 @@ func (n *nftState) applyProtoPortsRules(chainName string, chain *nftables.Chain,
 }
 
 func (n *nftState) applyPolicyPortsRules(chainName string, chain *nftables.Chain, policyName string, ports []multiv1beta1.MultiNetworkPolicyPort, portIndex int) error {
-	portsName := fmt.Sprintf("%s-%s-%d", chainName, portsChainSuffix, portIndex)
+	portsName := nftNameWithSuffix(chainName, "-", fmt.Sprintf("%s-%d", portsChainSuffix, portIndex))
 	// create ports chain
 	portChain, err := n.addChain(&nftables.Chain{
 		Name:  portsName,

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"net"
 	"net/netip"
@@ -82,6 +83,28 @@ func policyRuleNamespacedName(o *multiv1beta1.MultiNetworkPolicy) string {
 		return "<nil>"
 	}
 	return o.GetNamespace() + "-" + o.GetName()
+}
+
+const nftNameMaxLen = 255
+
+func sanitizeNftChar(r rune) rune {
+	if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+		return r
+	}
+	return '_'
+}
+
+func truncateNftName(name string, maxLen int) string {
+	sanitized := strings.Map(sanitizeNftChar, name)
+	if len(sanitized) <= maxLen {
+		return sanitized
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	suffix := fmt.Sprintf("-%x", h.Sum32())
+	prefix := sanitized[:maxLen-len(suffix)]
+	return prefix + suffix
 }
 
 func bootstrapNetfilterChains(nftState *nftState) {
@@ -1675,7 +1698,8 @@ func (n *nftState) applyPolicyPortsRules(chainName string, chain *nftables.Chain
 func (n *nftState) applyPodRules(s *Server, chain *nftables.Chain, podInfo *controllers.PodInfo, policy *multiv1beta1.MultiNetworkPolicy, policyNetworks []string) (bool, error) {
 	// add chain inet filter <chainName>-<idx>
 	entryChainName := chain.Name
-	policyChainName := fmt.Sprintf("%s-%s", entryChainName, policyRuleNamespacedName(policy))
+	policyPart := truncateNftName(policyRuleNamespacedName(policy), nftNameMaxLen-len(entryChainName)-1)
+	policyChainName := fmt.Sprintf("%s-%s", entryChainName, policyPart)
 	policyChain, err := n.addChain(&nftables.Chain{
 		Name:  policyChainName,
 		Table: n.filter,

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -96,13 +96,25 @@ func sanitizeNftChar(r rune) rune {
 }
 
 func truncateNftName(name string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
 	sanitized := strings.Map(sanitizeNftChar, name)
 	if len(sanitized) <= maxLen {
 		return sanitized
 	}
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(name))
-	suffix := fmt.Sprintf("-%x", h.Sum32())
+	// Use %08x for a deterministic 8-digit zero-padded suffix (9 chars with leading dash).
+	suffix := fmt.Sprintf("-%08x", h.Sum32())
+	if maxLen <= len(suffix) {
+		// maxLen is too small for the prefix+suffix; return the hash truncated to maxLen.
+		hash := suffix[1:] // drop the leading dash
+		if maxLen < len(hash) {
+			return hash[:maxLen]
+		}
+		return hash
+	}
 	prefix := sanitized[:maxLen-len(suffix)]
 	return prefix + suffix
 }
@@ -883,7 +895,16 @@ func ifname(n string) []byte {
 	return b
 }
 
+// userDataCommentMaxLen is the maximum length of a comment string in userdata.
+// userdata.AppendString encodes the string length in a single byte (0-255),
+// and appends a null terminator, so the effective maximum for the comment
+// string itself is 254 bytes.
+const userDataCommentMaxLen = 254
+
 func userDataComment(comment string) []byte {
+	if len(comment) > userDataCommentMaxLen {
+		comment = comment[:userDataCommentMaxLen]
+	}
 	return userdata.AppendString([]byte{}, userdata.TypeComment, comment)
 }
 

--- a/pkg/server/netfilterrules_sanitize_test.go
+++ b/pkg/server/netfilterrules_sanitize_test.go
@@ -178,6 +178,72 @@ func TestTruncateNftNameDeterministicSuffix(t *testing.T) {
 	}
 }
 
+func TestNftNameWithSuffixReservesSuffixBudget(t *testing.T) {
+	longBase := strings.Repeat("policy-", 80)
+	tests := []struct {
+		name      string
+		separator string
+		suffix    string
+	}{
+		{
+			name:      "ports chain",
+			separator: "-",
+			suffix:    portsChainSuffix + "-12",
+		},
+		{
+			name:      "peers chain",
+			separator: "-",
+			suffix:    peersChainSuffix + "-34",
+		},
+		{
+			name:      "tcp set",
+			separator: "_",
+			suffix:    "tcp",
+		},
+		{
+			name:      "udp set",
+			separator: "_",
+			suffix:    "udp",
+		},
+		{
+			name:      "sctp set",
+			separator: "_",
+			suffix:    "sctp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := nftNameWithSuffix(longBase, tt.separator, tt.suffix)
+			if len(result) > nftNameMaxLen {
+				t.Fatalf("nftNameWithSuffix result length %d exceeds %d: %q", len(result), nftNameMaxLen, result)
+			}
+			wantSuffix := tt.separator + tt.suffix
+			if !strings.HasSuffix(result, wantSuffix) {
+				t.Fatalf("nftNameWithSuffix result %q does not preserve suffix %q", result, wantSuffix)
+			}
+		})
+	}
+}
+
+func TestPolicyChildNftNamesStayWithinLimit(t *testing.T) {
+	policyChainName := truncateNftName(strings.Repeat("very-long-policy-", 40), nftNameMaxLen)
+	portsName := nftNameWithSuffix(policyChainName, "-", portsChainSuffix+"-123")
+	peersName := nftNameWithSuffix(policyChainName, "-", peersChainSuffix+"-456")
+
+	for name, value := range map[string]string{
+		"ports chain": portsName,
+		"peers chain": peersName,
+		"tcp set":     nftNameWithSuffix(getSetName(portsName), "_", "tcp"),
+		"udp set":     nftNameWithSuffix(getSetName(portsName), "_", "udp"),
+		"sctp set":    nftNameWithSuffix(getSetName(portsName), "_", "sctp"),
+	} {
+		if len(value) > nftNameMaxLen {
+			t.Fatalf("%s length %d exceeds %d: %q", name, len(value), nftNameMaxLen, value)
+		}
+	}
+}
+
 func TestUserDataCommentMaxLen(t *testing.T) {
 	// A comment within limit passes through unchanged.
 	short := strings.Repeat("a", 100)

--- a/pkg/server/netfilterrules_sanitize_test.go
+++ b/pkg/server/netfilterrules_sanitize_test.go
@@ -207,4 +207,3 @@ func TestUserDataCommentMaxLen(t *testing.T) {
 		t.Errorf("expected userdata length %d, got %d", 2+userDataCommentMaxLen+1, len(ud3))
 	}
 }
-

--- a/pkg/server/netfilterrules_sanitize_test.go
+++ b/pkg/server/netfilterrules_sanitize_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2025 Deutsche Telekom AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateNftName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		maxLen  int
+		wantLen int // expected len of result, -1 = no constraint checked individually
+		// wantExact is set when we know the exact expected output
+		wantExact string
+		// deterministic: call twice, must get same result
+		deterministic bool
+	}{
+		{
+			name:          "short name unchanged",
+			input:         "simple",
+			maxLen:        255,
+			wantLen:       6,
+			wantExact:     "simple",
+			deterministic: true,
+		},
+		{
+			name:          "name exactly at limit unchanged",
+			input:         strings.Repeat("a", 255),
+			maxLen:        255,
+			wantLen:       255,
+			deterministic: true,
+		},
+		{
+			name:          "overlong name truncated with hash suffix",
+			input:         strings.Repeat("a", 300),
+			maxLen:        255,
+			wantLen:       255,
+			deterministic: true,
+		},
+		{
+			name:          "overlong name with invalid chars — sanitized and truncated",
+			input:         "very-long-namespace/very-long-name-with$invalid@chars!" + strings.Repeat("x", 300),
+			maxLen:        255,
+			wantLen:       255,
+			deterministic: true,
+		},
+		{
+			name:          "invalid chars replaced with underscore in short name",
+			input:         "hello/world",
+			maxLen:        255,
+			wantLen:       11,
+			wantExact:     "hello_world",
+			deterministic: true,
+		},
+		{
+			name:          "maxLen zero returns empty string",
+			input:         "anyname",
+			maxLen:        0,
+			wantLen:       0,
+			wantExact:     "",
+			deterministic: true,
+		},
+		{
+			name:          "maxLen negative returns empty string",
+			input:         "anyname",
+			maxLen:        -1,
+			wantLen:       0,
+			wantExact:     "",
+			deterministic: true,
+		},
+		{
+			name:          "maxLen smaller than hash suffix returns hash truncated",
+			input:         strings.Repeat("z", 300),
+			maxLen:        5,
+			wantLen:       5,
+			deterministic: true,
+		},
+		{
+			name:          "maxLen equal to suffix length returns hash without dash (8 chars)",
+			input:         strings.Repeat("z", 300),
+			maxLen:        9, // suffix is "-XXXXXXXX" = 9 chars; maxLen<=len(suffix) so returns hash (8 chars)
+			wantLen:       8,
+			deterministic: true,
+		},
+		{
+			name:          "suffix is exactly 9 chars with zero-padded %08x",
+			input:         strings.Repeat("b", 300),
+			maxLen:        255,
+			wantLen:       255,
+			deterministic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateNftName(tt.input, tt.maxLen)
+
+			// Length check
+			if len(result) != tt.wantLen {
+				t.Errorf("truncateNftName(%q, %d) len = %d, want %d (result: %q)",
+					tt.input[:min(len(tt.input), 30)], tt.maxLen, len(result), tt.wantLen, result)
+			}
+
+			// Exact value check
+			if tt.wantExact != "" && result != tt.wantExact {
+				t.Errorf("truncateNftName(%q, %d) = %q, want %q",
+					tt.input, tt.maxLen, result, tt.wantExact)
+			}
+
+			// Determinism check
+			if tt.deterministic {
+				result2 := truncateNftName(tt.input, tt.maxLen)
+				if result != result2 {
+					t.Errorf("truncateNftName is not deterministic: got %q then %q", result, result2)
+				}
+			}
+
+			// Result must not exceed maxLen
+			if tt.maxLen > 0 && len(result) > tt.maxLen {
+				t.Errorf("truncateNftName(%q, %d) result length %d exceeds maxLen",
+					tt.input[:min(len(tt.input), 30)], tt.maxLen, len(result))
+			}
+
+			// Result must only contain valid nft chars (when non-empty)
+			if len(result) > 0 {
+				for i, r := range result {
+					if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+						(r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+						continue
+					}
+					t.Errorf("truncateNftName result contains invalid char %q at pos %d: %q", r, i, result)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestTruncateNftNameDeterministicSuffix(t *testing.T) {
+	// Verify that overlong names with the same content produce the same suffix (deterministic hash).
+	name := "very-long-namespace/overlong-name-that-exceeds-limit" + strings.Repeat("x", 250)
+	result1 := truncateNftName(name, 255)
+	result2 := truncateNftName(name, 255)
+
+	if result1 != result2 {
+		t.Errorf("truncateNftName is not deterministic: %q vs %q", result1, result2)
+	}
+	if len(result1) != 255 {
+		t.Errorf("expected result length 255, got %d", len(result1))
+	}
+
+	// Suffix should be exactly 9 chars: dash + 8 hex digits
+	suffix := result1[len(result1)-9:]
+	if suffix[0] != '-' {
+		t.Errorf("expected suffix to start with '-', got %q", suffix)
+	}
+	for _, c := range suffix[1:] {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			t.Errorf("suffix contains non-hex char %q in %q", c, suffix)
+		}
+	}
+}
+
+func TestUserDataCommentMaxLen(t *testing.T) {
+	// A comment within limit passes through unchanged.
+	short := strings.Repeat("a", 100)
+	ud := userDataComment(short)
+	// userdata TLV: [type][len][data...][null]
+	// type=0x00, len=101 (100+null), then 100 'a' bytes + null
+	if len(ud) != 2+len(short)+1 {
+		t.Errorf("unexpected userdata length for short comment: %d", len(ud))
+	}
+
+	// A comment exactly at limit (254 bytes) is allowed.
+	atLimit := strings.Repeat("b", userDataCommentMaxLen)
+	ud2 := userDataComment(atLimit)
+	// length field should be 255 (254 + null)
+	if ud2[1] != 255 {
+		t.Errorf("expected length byte 255, got %d", ud2[1])
+	}
+
+	// A comment exceeding the limit is truncated to 254 bytes.
+	overlong := strings.Repeat("c", 300)
+	ud3 := userDataComment(overlong)
+	// length field should be 255 (254 + null), not overflow
+	if ud3[1] != 255 {
+		t.Errorf("expected length byte 255 for overlong comment, got %d", ud3[1])
+	}
+	if len(ud3) != 2+userDataCommentMaxLen+1 {
+		t.Errorf("expected userdata length %d, got %d", 2+userDataCommentMaxLen+1, len(ud3))
+	}
+}
+


### PR DESCRIPTION
## Summary

nftables chain names derived from `MultiNetworkPolicy` namespace + name are not bounded. The kernel enforces `NFT_NAME_MAXLEN = 256` bytes for all nftables object names. A policy in the longest-allowed namespace (63 chars) with the longest-allowed name (253 chars) produces a chain name of `multi-ingress-<63>-<253>` = 330 bytes, exceeding the limit. `nft.Flush()` fails with `ENAMETOOLONG`, leaving the pod without any network policy enforcement.

Additionally, character classes not valid in kernel nftables identifiers (e.g. `/`, `@`, unicode) would silently pass through and potentially cause errors or unexpected behaviour.

## Root Cause

```go
policyChainName := fmt.Sprintf("%s-%s", entryChainName, policyRuleNamespacedName(policy))
// policyRuleNamespacedName = namespace + "-" + name, unbounded
```

## Fix

Add `truncateNftName(name, maxLen)`:
1. Sanitize: replace characters outside `[a-zA-Z0-9._-]` with `_`
2. Truncate: if the sanitized string exceeds `maxLen`, keep a prefix and append `-<fnv32hex>` (9 chars total) to ensure stable uniqueness across policies with matching prefixes

Apply in `applyPodRules` where the per-policy chain name is constructed, computing the available budget as `nftNameMaxLen - len(entryChainName) - 1` (the `-1` accounts for the separator).

## Impact

- Policies with long names/namespaces now produce valid, bounded chain names.
- Short, common names (the vast majority) pass through unchanged (the sanitizer is a no-op on valid DNS labels).
- Hash suffix is deterministic: same policy always produces the same chain name across restarts, so chain cleanup (by name) continues to work correctly.