### PR TITLE
fix: wrap returned errors

### DIFF
--- a/pkg/controllers/namespace.go
+++ b/pkg/controllers/namespace.go
@@ -67,7 +67,7 @@ func NewNamespaceConfig(nsInformer coreinformers.NamespaceInformer, resyncPeriod
 		resyncPeriod,
 	)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("cannot add namespace informer event handler: %v", err))
+		utilruntime.HandleError(fmt.Errorf("cannot add namespace informer event handler: %w", err))
 	}
 	return result
 }

--- a/pkg/controllers/net-attach-def.go
+++ b/pkg/controllers/net-attach-def.go
@@ -71,7 +71,7 @@ func NewNetDefConfig(netdefInformer netdefinformerv1.NetworkAttachmentDefinition
 		}, resyncPeriod,
 	)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("cannot add net-attach-def informer event handler: %v", err))
+		utilruntime.HandleError(fmt.Errorf("cannot add net-attach-def informer event handler: %w", err))
 	}
 
 	return result

--- a/pkg/controllers/networkpolicy.go
+++ b/pkg/controllers/networkpolicy.go
@@ -68,7 +68,7 @@ func NewNetworkPolicyConfig(policyInformer multiinformerv1beta1.MultiNetworkPoli
 		}, resyncPeriod,
 	)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("cannot add multi-networkpolicy informer event handler: %v", err))
+		utilruntime.HandleError(fmt.Errorf("cannot add multi-networkpolicy informer event handler: %w", err))
 	}
 
 	return result

--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -111,7 +111,7 @@ func NewPodConfig(podInformer coreinformers.PodInformer, resyncPeriod time.Durat
 		resyncPeriod,
 	)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("cannot add pod informer event handler: %v", err))
+		utilruntime.HandleError(fmt.Errorf("cannot add pod informer event handler: %w", err))
 	}
 	return result
 }
@@ -302,14 +302,14 @@ func (pct *PodChangeTracker) getPodNetNSPath(pod *v1.Pod) (string, error) {
 			defer rpcCancel()
 			r, err := pct.criClient.ContainerStatus(rpcCtx, request)
 			if err != nil {
-				return "", fmt.Errorf("cannot get containerStatus: %v", err)
+				return "", fmt.Errorf("cannot get containerStatus: %w", err)
 			}
 
 			info := r.GetInfo()
 			var infop interface{}
 			err = json.Unmarshal([]byte(info["info"]), &infop)
 			if err != nil {
-				return "", fmt.Errorf("cannot unmarshal containerStatus info: %v", err)
+				return "", fmt.Errorf("cannot unmarshal containerStatus info: %w", err)
 			}
 			pid, ok := infop.(map[string]interface{})["pid"].(float64)
 			if !ok {
@@ -597,7 +597,7 @@ func GetCriRuntimeClient(runtimeEndpoint, hostPrefix string) (pb.RuntimeServiceC
 	// Set up a connection to the server.
 	conn, err := getRuntimeClientConnection(runtimeEndpoint, hostPrefix)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to connect: %v", err)
+		return nil, nil, fmt.Errorf("failed to connect: %w", err)
 	}
 	runtimeClient := pb.NewRuntimeServiceClient(conn)
 	return runtimeClient, conn, nil

--- a/pkg/server/netfilterrules.go
+++ b/pkg/server/netfilterrules.go
@@ -629,7 +629,7 @@ func getPrefixesAsSetInterval(prefixes []string) ([]nftables.SetElement, []nftab
 	for index, addr := range prefixes {
 		net, err := netip.ParsePrefix(addr) // validate
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse CIDR %q prefix[%d]: %v", addr, index, err)
+			return nil, nil, fmt.Errorf("failed to parse CIDR %q prefix[%d]: %w", addr, index, err)
 		}
 		if net.Addr().Is4() {
 			// specific first element to inform nftables this is an interval set
@@ -789,45 +789,45 @@ func (n *nftState) applyCommonChainRules(s *Server) error {
 	klog.V(8).Info("applying common chain rules")
 	if s.Options.acceptICMPv6 {
 		if err := n.allowICMP(n.commonIngressChain, true); err != nil {
-			return fmt.Errorf("failed to allow ICMPv6 in common ingress chain: %v", err)
+			return fmt.Errorf("failed to allow ICMPv6 in common ingress chain: %w", err)
 		}
 		if err := n.allowICMP(n.commonEgressChain, true); err != nil {
-			return fmt.Errorf("failed to allow ICMPv6 in common egress chain: %v", err)
+			return fmt.Errorf("failed to allow ICMPv6 in common egress chain: %w", err)
 		}
 	} else {
 		if err := n.allowNeighborDiscovery(n.commonIngressChain); err != nil {
-			return fmt.Errorf("failed to allow ICMPv6 neighbor discovery in common ingress chain: %v", err)
+			return fmt.Errorf("failed to allow ICMPv6 neighbor discovery in common ingress chain: %w", err)
 		}
 		if err := n.allowNeighborDiscovery(n.commonEgressChain); err != nil {
-			return fmt.Errorf("failed to allow ICMPv6 neighbor discovery in common egress chain: %v", err)
+			return fmt.Errorf("failed to allow ICMPv6 neighbor discovery in common egress chain: %w", err)
 		}
 	}
 	if s.Options.acceptICMP {
 		if err := n.allowICMP(n.commonIngressChain, false); err != nil {
-			return fmt.Errorf("failed to allow ICMP in common ingress chain: %v", err)
+			return fmt.Errorf("failed to allow ICMP in common ingress chain: %w", err)
 		}
 		if err := n.allowICMP(n.commonEgressChain, false); err != nil {
-			return fmt.Errorf("failed to allow ICMP in common egress chain: %v", err)
+			return fmt.Errorf("failed to allow ICMP in common egress chain: %w", err)
 		}
 	}
 
 	if len(s.Options.allowSrcPrefix) != 0 {
 		if err := n.applyCommonPrefixRules(n.commonIngressChain, s.Options.allowSrcPrefix, common); err != nil {
-			return fmt.Errorf("failed to apply common ingress rules: %v", err)
+			return fmt.Errorf("failed to apply common ingress rules: %w", err)
 		}
 	}
 
 	if len(s.Options.allowDstPrefix) != 0 {
 		if err := n.applyCommonPrefixRules(n.commonEgressChain, s.Options.allowDstPrefix, common); err != nil {
-			return fmt.Errorf("failed to apply common egress rules: %v", err)
+			return fmt.Errorf("failed to apply common egress rules: %w", err)
 		}
 	}
 	// Always allow conntracked connections
 	if err := n.allowConntracked(n.commonIngressChain); err != nil {
-		return fmt.Errorf("failed to apply common ingress conntrack rules: %v", err)
+		return fmt.Errorf("failed to apply common ingress conntrack rules: %w", err)
 	}
 	if err := n.allowConntracked(n.commonEgressChain); err != nil {
-		return fmt.Errorf("failed to apply common egress conntrack rules: %v", err)
+		return fmt.Errorf("failed to apply common egress conntrack rules: %w", err)
 	}
 
 	return nil
@@ -1689,7 +1689,7 @@ func (n *nftState) applyPodRules(s *Server, chain *nftables.Chain, podInfo *cont
 		if podIntf.CheckPolicyNetwork(policyNetworks) {
 			newRule, err := n.applyPodInterfaceRules(chain, policyChain, policy, podIntf)
 			if err != nil {
-				return newRules, fmt.Errorf("failed to apply pod interface rules for policy %q: %v", policyNamespacedName(policy), err)
+				return newRules, fmt.Errorf("failed to apply pod interface rules for policy %q: %w", policyNamespacedName(policy), err)
 			}
 			if newRule {
 				newRules = true


### PR DESCRIPTION
## Summary
- convert returned error formatting to wrapped errors in controller and nftables paths
- keep non-error object formatting unchanged

## Tests
- make fmt
- git diff --check
- make build GOOS=linux
- GOOS=linux make vet

Note: full make test requires Linux/root nftables access.