### PR TITLE
fix(e2e): wait for CNI installer rollout

### DIFF
--- a/e2e/setup_cluster.sh
+++ b/e2e/setup_cluster.sh
@@ -42,7 +42,7 @@ kubectl -n kube-system wait --for=condition=available deploy/coredns --timeout=3
 kubectl apply --wait --timeout=10s -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset.yml
 kubectl -n kube-system wait --for=condition=ready -l name=multus pod --timeout=660s
 kubectl apply --wait --timeout=10s -f cni-install.yml
-kubectl -n kube-system wait --for=condition=ready -l name=cni-plugins pod --timeout=300s
+kubectl -n kube-system rollout status daemonset/install-cni-plugins --timeout=300s
 
 #install bond-cni
 kubectl apply --wait --timeout=10s -f  https://raw.githubusercontent.com/k8snetworkplumbingwg/bond-cni/refs/heads/master/manifests/bond-cni.yaml


### PR DESCRIPTION
## Summary

- wait for the CNI installer DaemonSet rollout instead of querying pods by label immediately after apply

## Why

The PR 81 `e2e-kind` job failed during `Setup cluster` after `cni-install.yml` was applied:

```text
daemonset.apps/install-cni-plugins created
error: no matching resources found
```

The failing command was:

```sh
kubectl -n kube-system wait --for=condition=ready -l name=cni-plugins pod --timeout=300s
```

That query can race DaemonSet pod creation. Waiting on `daemonset/install-cni-plugins` uses the controller that was just created and lets Kubernetes wait until the rollout is available.

## Validation

- `sh -n e2e/setup_cluster.sh`
- `git diff --check`

Full kind e2e was not run locally because this user cannot access the Docker socket (`permission denied while trying to connect to the docker API at unix:///var/run/docker.sock`).
